### PR TITLE
Update PWA README

### DIFF
--- a/sober-body-pwa/README.md
+++ b/sober-body-pwa/README.md
@@ -1,5 +1,21 @@
 # React + TypeScript + Vite
 
+This directory contains the React + TypeScript front end for **Sober‑Body** built with [Vite](https://vitejs.dev/).
+
+## Basic usage
+
+```bash
+npm install      # install dependencies
+npm run dev      # start the dev server
+npm test         # run unit tests
+npm run build    # create a production build
+```
+
+For more project information see the [root README](../README.md) and the
+[contribution guide](../docs/Contributing.md).
+
+---
+
 This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
 
 Currently, two official plugins are available:


### PR DESCRIPTION
## Summary
- clarify that `sober-body-pwa/` contains the React + TypeScript front end
- add quick-start commands and links to the root README and contributing guide

## Testing
- `npm install`
- `npm run lint`
- `npm test`
- `npm run build` *(fails: 'test' option not in `UserConfigExport`)*

------
https://chatgpt.com/codex/tasks/task_e_6859e5f11288832bbb62539ba9077757