### PR TITLE
feat(ui): add DrinkButtons component

### DIFF
--- a/docs/Backlog.md
+++ b/docs/Backlog.md
@@ -17,7 +17,7 @@ Legend: **↑ = next up** · ✅ done · ⬜ open
 ## UI & UX
 
 * ⬜ **feat(ui):** replace Vite splash with `<BacDashboard>` (hard‑coded demo)
-* ⬜ **feat(ui):** DrinkButtons (Beer 🍺 Wine 🍷 Shot 🥃)
+* ✅ **feat(ui):** DrinkButtons (Beer 🍺 Wine 🍷 Shot 🥃)
 * ⬜ **feat(ui):** Settings modal (weight, sex, beta slider)
 
 ## Storage & PWA

--- a/sober-body-pwa/package.json
+++ b/sober-body-pwa/package.json
@@ -26,6 +26,8 @@
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.30.1",
     "vite": "^6.3.5",
-    "vitest": "^1.6.1"
+    "vitest": "^1.6.1",
+    "@testing-library/react": "^16.3.0",
+    "jsdom": "^26.1.0"
   }
 }

--- a/sober-body-pwa/src/App.tsx
+++ b/sober-body-pwa/src/App.tsx
@@ -1,34 +1,11 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
 import './App.css'
-
+import DrinkButtons from './features/ui/DrinkButtons'
 function App() {
-  const [count, setCount] = useState(0)
-
   return (
-    <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.tsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
-    </>
+    <div className="app">
+      <h1>Sober-Body</h1>
+      <DrinkButtons />
+    </div>
   )
 }
 

--- a/sober-body-pwa/src/features/ui/DrinkButtons.test.tsx
+++ b/sober-body-pwa/src/features/ui/DrinkButtons.test.tsx
@@ -1,0 +1,12 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import DrinkButtons from './DrinkButtons'
+
+describe('DrinkButtons', () => {
+  it('renders all drink buttons', () => {
+    render(<DrinkButtons />)
+    expect(screen.getByRole('button', { name: /beer/i })).toBeTruthy()
+    expect(screen.getByRole('button', { name: /wine/i })).toBeTruthy()
+    expect(screen.getByRole('button', { name: /shot/i })).toBeTruthy()
+  })
+})

--- a/sober-body-pwa/src/features/ui/DrinkButtons.tsx
+++ b/sober-body-pwa/src/features/ui/DrinkButtons.tsx
@@ -1,0 +1,11 @@
+import React from 'react'
+
+export default function DrinkButtons() {
+  return (
+    <div>
+      <button aria-label="add beer">Beer 🍺</button>
+      <button aria-label="add wine">Wine 🍷</button>
+      <button aria-label="add shot">Shot 🥃</button>
+    </div>
+  )
+}

--- a/sober-body-pwa/vite.config.ts
+++ b/sober-body-pwa/vite.config.ts
@@ -5,6 +5,6 @@ import react from '@vitejs/plugin-react'
 export default defineConfig({
   plugins: [react()],
   test: {
-    environment: 'node',
+    environment: 'jsdom',
   },
 })


### PR DESCRIPTION
## Summary
- add simple `DrinkButtons` component with Beer/Wine/Shot buttons
- test buttons render correctly
- hook new component into `App`
- switch Vitest to jsdom environment
- mark backlog item as complete

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6859f3ea00a0832b8bde1a75c38f7e7a