### PR TITLE
feat(ui): add BacDashboard demo

### DIFF
--- a/docs/Backlog.md
+++ b/docs/Backlog.md
@@ -16,7 +16,7 @@ Legend: **↑ = next up** · ✅ done · ⬜ open
 
 ## UI & UX
 
-* ⬜ **feat(ui):** replace Vite splash with `<BacDashboard>` (hard‑coded demo)
+* ✅ **feat(ui):** replace Vite splash with `<BacDashboard>` (hard‑coded demo)
 * ✅ **feat(ui):** DrinkButtons (Beer 🍺 Wine 🍷 Shot 🥃)
 * ⬜ **feat(ui):** Settings modal (weight, sex, beta slider)
 

--- a/sober-body-pwa/src/App.tsx
+++ b/sober-body-pwa/src/App.tsx
@@ -1,10 +1,9 @@
 import './App.css'
-import DrinkButtons from './features/ui/DrinkButtons'
+import BacDashboard from './features/ui/BacDashboard'
 function App() {
   return (
     <div className="app">
-      <h1>Sober-Body</h1>
-      <DrinkButtons />
+      <BacDashboard />
     </div>
   )
 }

--- a/sober-body-pwa/src/features/ui/BacDashboard.test.tsx
+++ b/sober-body-pwa/src/features/ui/BacDashboard.test.tsx
@@ -1,0 +1,11 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import BacDashboard from './BacDashboard'
+
+describe('BacDashboard', () => {
+  it('renders BAC and hours', () => {
+    render(<BacDashboard />)
+    expect(screen.getByTestId('bac')).toBeTruthy()
+    expect(screen.getByTestId('hours')).toBeTruthy()
+  })
+})

--- a/sober-body-pwa/src/features/ui/BacDashboard.tsx
+++ b/sober-body-pwa/src/features/ui/BacDashboard.tsx
@@ -1,0 +1,21 @@
+import React from 'react'
+import { estimateBAC, hoursToSober, DrinkEvent, Physiology } from '../core/bac'
+
+const DEMO_DRINKS: DrinkEvent[] = [
+  { volumeMl: 330, abv: 0.05, date: new Date(Date.now() - 60 * 60 * 1000) },
+  { volumeMl: 150, abv: 0.12, date: new Date(Date.now() - 30 * 60 * 1000) }
+]
+
+const DEMO_PHYSIOLOGY: Physiology = { weightKg: 70, sex: 'm' }
+
+export default function BacDashboard() {
+  const bac = estimateBAC(DEMO_DRINKS, DEMO_PHYSIOLOGY)
+  const hours = hoursToSober(bac, DEMO_PHYSIOLOGY)
+  return (
+    <div>
+      <h1>Demo BAC Dashboard</h1>
+      <p data-testid="bac">BAC: {bac.toFixed(3)}%</p>
+      <p data-testid="hours">Hours to sober: {hours.toFixed(1)}</p>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add `BacDashboard` component with demo BAC data
- test rendering of dashboard
- show dashboard in `App`
- check backlog item

## Testing
- `npm run lint --prefix sober-body-pwa`
- `npm test --prefix sober-body-pwa`


------
https://chatgpt.com/codex/tasks/task_e_6859f9810dd0832b99792fb5fcf817ff