### PR TITLE
feat(ui): add Dashboard v0

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -17,7 +17,7 @@ Legend: **↑ = next up** · ✅ done · ⬜ open
 ## UI & UX
 
 * ⬜ **feat(ui):** replace Vite splash with `<BacDashboard>` (hard‑coded demo)
-* ✅ **feat(ui):** DrinkButtons (Beer 🍺 Wine 🍷 Shot 🥃)
+* ✅ **feat(ui):** DrinkButtons component (Beer 🍺 Wine 🍷 Shot 🥃)
 * ⬜ **feat(ui):** Settings modal (weight, sex, beta slider)
 
 ## Storage & PWA

--- a/sober-body-pwa/src/App.tsx
+++ b/sober-body-pwa/src/App.tsx
@@ -1,11 +1,13 @@
 import './App.css'
-import DrinkButtons from './features/ui/DrinkButtons'
+import BacDashboard from './components/BacDashboard'
+import { DrinkLogProvider } from './features/core/drink-context'
 function App() {
   return (
-    <div className="app">
-      <h1>Sober-Body</h1>
-      <DrinkButtons />
-    </div>
+    <DrinkLogProvider>
+      <div className="app">
+        <BacDashboard />
+      </div>
+    </DrinkLogProvider>
   )
 }
 

--- a/sober-body-pwa/src/components/BacDashboard.test.tsx
+++ b/sober-body-pwa/src/components/BacDashboard.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen, fireEvent, cleanup } from '@testing-library/react'
+import { describe, it, expect, afterEach } from 'vitest'
+import { DrinkLogProvider, useDrinkLog } from '../features/core/drink-context'
+import DrinkButtons from './DrinkButtons'
+import { estimateBAC } from '../features/core/bac'
+
+function LogLength() {
+  const { log } = useDrinkLog()
+  return <div data-testid="length">{log.length}</div>
+}
+
+function BacValue() {
+  const { log } = useDrinkLog()
+  const bac = estimateBAC(log, { weightKg: 70, sex: 'm' })
+  return <div data-testid="bac">{bac}</div>
+}
+
+describe('BacDashboard interactions', () => {
+  afterEach(() => cleanup())
+  it('clicking Beer increases log length', () => {
+    render(
+      <DrinkLogProvider>
+        <DrinkButtons />
+        <LogLength />
+      </DrinkLogProvider>
+    )
+    expect(screen.getByTestId('length').textContent).toBe('0')
+    fireEvent.click(screen.getByRole('button', { name: /beer/i }))
+    expect(screen.getByTestId('length').textContent).toBe('1')
+  })
+
+  it('BAC > 0 after adding Shot', () => {
+    render(
+      <DrinkLogProvider>
+        <DrinkButtons />
+        <BacValue />
+      </DrinkLogProvider>
+    )
+    fireEvent.click(screen.getByRole('button', { name: /shot/i }))
+    const value = Number(screen.getByTestId('bac').textContent)
+    expect(value).toBeGreaterThan(0)
+  })
+})

--- a/sober-body-pwa/src/components/BacDashboard.tsx
+++ b/sober-body-pwa/src/components/BacDashboard.tsx
@@ -1,0 +1,20 @@
+import React from 'react'
+import { estimateBAC, hoursToSober } from '../features/core/bac'
+import { useDrinkLog } from '../features/core/drink-context'
+import DrinkButtons from './DrinkButtons'
+
+export default function BacDashboard() {
+  const { log } = useDrinkLog()
+  const physiology = { weightKg: 70, sex: 'm' } as const
+  const bac = estimateBAC(log, physiology)
+  const sober = hoursToSober(bac, physiology)
+
+  return (
+    <div>
+      <h1>BAC Dashboard</h1>
+      <p>Current BAC: {bac.toFixed(3)}%</p>
+      <p>Hours to sober: {sober.toFixed(1)}</p>
+      <DrinkButtons />
+    </div>
+  )
+}

--- a/sober-body-pwa/src/components/DrinkButtons.tsx
+++ b/sober-body-pwa/src/components/DrinkButtons.tsx
@@ -1,0 +1,21 @@
+import React from 'react'
+import { useDrinkLog } from '../features/core/drink-context'
+
+export default function DrinkButtons() {
+  const { addDrink } = useDrinkLog()
+
+  const now = () => new Date()
+  return (
+    <div>
+      <button aria-label="add beer" onClick={() => addDrink({ volumeMl: 330, abv: 0.05, date: now() })}>
+        Beer 🍺
+      </button>
+      <button aria-label="add wine" onClick={() => addDrink({ volumeMl: 150, abv: 0.12, date: now() })}>
+        Wine 🍷
+      </button>
+      <button aria-label="add shot" onClick={() => addDrink({ volumeMl: 45, abv: 0.4, date: now() })}>
+        Shot 🥃
+      </button>
+    </div>
+  )
+}

--- a/sober-body-pwa/src/features/core/drink-context.tsx
+++ b/sober-body-pwa/src/features/core/drink-context.tsx
@@ -1,0 +1,26 @@
+/* eslint-disable react-refresh/only-export-components */
+import React, { createContext, useContext, useState } from 'react'
+import { DrinkEvent } from './bac'
+
+export interface DrinkLogValue {
+  log: DrinkEvent[]
+  addDrink: (d: DrinkEvent) => void
+}
+
+const DrinkLogContext = createContext<DrinkLogValue | undefined>(undefined)
+
+export function DrinkLogProvider({ children }: { children: React.ReactNode }) {
+  const [log, setLog] = useState<DrinkEvent[]>([])
+  const addDrink = (d: DrinkEvent) => setLog(prev => [...prev, d])
+  return (
+    <DrinkLogContext.Provider value={{ log, addDrink }}>
+      {children}
+    </DrinkLogContext.Provider>
+  )
+}
+
+export function useDrinkLog() {
+  const ctx = useContext(DrinkLogContext)
+  if (!ctx) throw new Error('useDrinkLog must be used within DrinkLogProvider')
+  return ctx
+}


### PR DESCRIPTION
## Summary
- replace App content with a basic BAC dashboard
- add DrinkButtons hooked to a DrinkLog context
- implement in-memory DrinkLogContext
- document DrinkButtons completion in BACKLOG
- add dashboard interaction tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685a0a48d180832bae9580ae1cb7ab9f