### PR TITLE
fix import error for DrinkEvent

### DIFF
--- a/sober-body-pwa/src/features/core/drink-context.tsx
+++ b/sober-body-pwa/src/features/core/drink-context.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react-refresh/only-export-components */
 import React, { createContext, useContext, useState } from 'react'
-import { DrinkEvent } from './bac'
+import { type DrinkEvent } from './bac'
 
 export interface DrinkLogValue {
   log: DrinkEvent[]


### PR DESCRIPTION
## Summary
- fix drink context interface import to be type-only to avoid runtime error

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685a0c4e4058832b887cd5b0a2a01bfc