### PR TITLE
fix(core): correct Widmark weight units

### DIFF
--- a/sober-body-pwa/src/features/core/bac.test.ts
+++ b/sober-body-pwa/src/features/core/bac.test.ts
@@ -13,7 +13,7 @@ describe('BAC core utilities', () => {
     const physiology = { weightKg: 70, sex: 'm' } as const
     const hours = 1
     const r = 0.68
-    const expected = Math.max((grams / (physiology.weightKg * r)) * 100 - DEFAULT_BETA * hours, 0)
+    const expected = Math.max((grams / (physiology.weightKg * 1000 * r)) * 100 - DEFAULT_BETA * hours, 0)
     expect(widmark(grams, physiology, hours)).toBeCloseTo(expected)
   })
 
@@ -27,9 +27,9 @@ describe('BAC core utilities', () => {
     const r = 0.68
     const g1 = drink1.volumeMl * drink1.abv * dens
     const g2 = drink2.volumeMl * drink2.abv * dens
-    let bac = (g1 / (physiology.weightKg * r)) * 100
+    let bac = (g1 / (physiology.weightKg * 1000 * r)) * 100
     bac = Math.max(bac - DEFAULT_BETA * 1, 0)
-    bac += (g2 / (physiology.weightKg * r)) * 100
+    bac += (g2 / (physiology.weightKg * 1000 * r)) * 100
     bac = Math.max(bac - DEFAULT_BETA * 1, 0)
 
     const expected = bac

--- a/sober-body-pwa/src/features/core/bac.ts
+++ b/sober-body-pwa/src/features/core/bac.ts
@@ -58,7 +58,7 @@ export function widmark(
   const r = physiology.r ?? R_CONST[physiology.sex];
   const beta = physiology.beta ?? DEFAULT_BETA;
 
-  const raw = (grams / (physiology.weightKg * r)) * 100; // %BAC
+  const raw = (grams / (physiology.weightKg * 1000 * r)) * 100; // %BAC
   const adjusted = raw - beta * hoursSinceDrink;
   return Math.max(adjusted, 0);
 }
@@ -88,7 +88,7 @@ export function estimateBAC(
     if (gap < 0) gap = 0;
     bac = Math.max(bac - beta * gap, 0);
 
-    const raw = (gramsFromDrink(d) / (physiology.weightKg * r)) * 100;
+    const raw = (gramsFromDrink(d) / (physiology.weightKg * 1000 * r)) * 100;
     bac += raw;
 
     last = d.date;


### PR DESCRIPTION
## Summary
- fix weight unit handling in bac.ts Widmark formula
- update unit tests for corrected calculation

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685a0f387760832bac30be7f6836dbdb