### PR TITLE
feat(storage): IndexedDB persistence

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -22,7 +22,7 @@ For engineers & AI contributors – see white‑papers for business context.
 │  ├─ games/   🎮 ReactionTap, Stroop                                      │
 │  └─ group/   👥 QR join + WebSocket hub                                  │
 │                                                                         │
-│  Storage: IndexedDB (idb‑keyval)                                         │
+│  Storage: IndexedDB (idb‑keyval) – drink log & settings persistence      │
 └───────────────────────────────────────────────────────────────────────────┘
 ```
 
@@ -34,7 +34,7 @@ For engineers & AI contributors – see white‑papers for business context.
 | ------- | ----------------------------------- | -------------------------------------- |
 | UI      | **React 18 + TypeScript 5**         | Vite dev server, Tailwind optional     |
 | State   | Context → Redux Toolkit (future)    | TBD after DrinkButtons                 |
-| Storage | **IndexedDB** via `idb-keyval@6`    | fallback to in‑memory for unit tests   |
+| Storage | **IndexedDB** via `idb-keyval@6`    | drink log & settings, in‑memory for tests |
 | Core    | TS → **Rust 1.79 → WASM** (phase 2) | FFI boundary typed via ts‑wasm‑bindgen |
 | Tests   | **Vitest 1.6** + jsdom              | Live in `src/**/__tests__`             |
 | CI      | GitHub Actions Node 20              | see `ci.yml`                           |

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -24,7 +24,7 @@ Legend: **↑ = next up** · ✅ done · ⬜ open
 
 ## Storage & PWA
 
-* ⬜ **feat(storage):** IndexedDB wrapper (`idb-keyval`) for drink log
+* ✅ **feat(storage):** IndexedDB wrapper (`idb-keyval`) for drink log
 * ⬜ **chore(pwa):** add `vite-plugin-pwa` + minimal manifest
 
 ## Group Features

--- a/sober-body-pwa/package-lock.json
+++ b/sober-body-pwa/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "canvas-confetti": "^1.9.3",
         "framer-motion": "^12.19.1",
+        "idb-keyval": "^6.2.2",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-router-dom": "^6.30.1"
@@ -25,6 +26,7 @@
         "eslint": "^9.25.0",
         "eslint-plugin-react-hooks": "^5.2.0",
         "eslint-plugin-react-refresh": "^0.4.19",
+        "fake-indexeddb": "^5.0.2",
         "globals": "^16.0.0",
         "jsdom": "^26.1.0",
         "postcss": "^8.5.6",
@@ -3060,6 +3062,16 @@
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
     },
+    "node_modules/fake-indexeddb": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/fake-indexeddb/-/fake-indexeddb-5.0.2.tgz",
+      "integrity": "sha512-cB507r5T3D55DfclY01GLkninZLfU7HXV/mhVRTnTRm5k2u+fY7Fof2dBkr80p5t7G7dlA/G5dI87QiMdPpMCQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -3381,6 +3393,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/idb-keyval": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-6.2.2.tgz",
+      "integrity": "sha512-yjD9nARJ/jb1g+CvD0tlhUHOrJ9Sy0P8T9MF3YaLlHnSRpwPfpTX0XIvpmw3gAJUmEu3FiICLBDPXVwyEvrleg==",
+      "license": "Apache-2.0"
     },
     "node_modules/ignore": {
       "version": "5.3.2",

--- a/sober-body-pwa/package.json
+++ b/sober-body-pwa/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "canvas-confetti": "^1.9.3",
     "framer-motion": "^12.19.1",
+    "idb-keyval": "^6.2.2",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router-dom": "^6.30.1"
@@ -28,6 +29,7 @@
     "eslint": "^9.25.0",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.19",
+    "fake-indexeddb": "^5.0.2",
     "globals": "^16.0.0",
     "jsdom": "^26.1.0",
     "postcss": "^8.5.6",

--- a/sober-body-pwa/src/components/BacDashboard.test.tsx
+++ b/sober-body-pwa/src/components/BacDashboard.test.tsx
@@ -1,17 +1,18 @@
 import { render, screen, fireEvent, cleanup } from '@testing-library/react'
 import { describe, it, expect, afterEach } from 'vitest'
+import 'fake-indexeddb/auto'
 import { DrinkLogProvider, useDrinkLog } from '../features/core/drink-context'
 import DrinkButtons from './DrinkButtons'
 import { estimateBAC } from '../features/core/bac'
 
 function LogLength() {
-  const { log } = useDrinkLog()
-  return <div data-testid="length">{log.length}</div>
+  const { drinks } = useDrinkLog()
+  return <div data-testid="length">{drinks.length}</div>
 }
 
 function BacValue() {
-  const { log } = useDrinkLog()
-  const bac = estimateBAC(log, { weightKg: 70, sex: 'm' })
+  const { drinks } = useDrinkLog()
+  const bac = estimateBAC(drinks, { weightKg: 70, sex: 'm' })
   return <div data-testid="bac">{bac}</div>
 }
 

--- a/sober-body-pwa/src/components/BacDashboard.tsx
+++ b/sober-body-pwa/src/components/BacDashboard.tsx
@@ -4,9 +4,9 @@ import { useDrinkLog } from '../features/core/drink-context'
 import DrinkButtons from './DrinkButtons'
 
 export default function BacDashboard() {
-  const { log } = useDrinkLog()
+  const { drinks } = useDrinkLog()
   const physiology = { weightKg: 70, sex: 'm' } as const
-  const bac = estimateBAC(log, physiology)
+  const bac = estimateBAC(drinks, physiology)
   const sober = hoursToSober(bac, physiology)
 
   return (

--- a/sober-body-pwa/src/features/core/drink-context.tsx
+++ b/sober-body-pwa/src/features/core/drink-context.tsx
@@ -1,19 +1,32 @@
 /* eslint-disable react-refresh/only-export-components */
-import React, { createContext, useContext, useState } from 'react'
+import React, { createContext, useContext, useState, useEffect } from 'react'
 import { type DrinkEvent } from './bac'
+import { loadDrinks, saveDrinks } from './storage'
 
 export interface DrinkLogValue {
-  log: DrinkEvent[]
+  drinks: DrinkEvent[]
   addDrink: (d: DrinkEvent) => void
+  clear: () => void
 }
 
 const DrinkLogContext = createContext<DrinkLogValue | undefined>(undefined)
 
 export function DrinkLogProvider({ children }: { children: React.ReactNode }) {
-  const [log, setLog] = useState<DrinkEvent[]>([])
-  const addDrink = (d: DrinkEvent) => setLog(prev => [...prev, d])
+  const [drinks, setDrinks] = useState<DrinkEvent[]>([])
+
+  useEffect(() => {
+    loadDrinks().then(setDrinks)
+  }, [])
+
+  useEffect(() => {
+    saveDrinks(drinks)
+  }, [drinks])
+
+  const addDrink = (d: DrinkEvent) => setDrinks(prev => [...prev, d])
+  const clear = () => setDrinks([])
+
   return (
-    <DrinkLogContext.Provider value={{ log, addDrink }}>
+    <DrinkLogContext.Provider value={{ drinks, addDrink, clear }}>
       {children}
     </DrinkLogContext.Provider>
   )

--- a/sober-body-pwa/src/features/core/storage.test.ts
+++ b/sober-body-pwa/src/features/core/storage.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import 'fake-indexeddb/auto'
+import { loadDrinks, saveDrinks } from './storage'
+import { type DrinkEvent } from './bac'
+
+async function clearDB() {
+  const dbs = await indexedDB.databases?.()
+  if (dbs) await Promise.all(dbs.map(db => indexedDB.deleteDatabase(db.name!)))
+}
+
+describe('storage helpers', () => {
+  beforeEach(async () => {
+    await clearDB()
+  })
+
+  it('addDrink persists value', async () => {
+    const drink: DrinkEvent = { volumeMl: 100, abv: 0.05, date: new Date() }
+    await saveDrinks([drink])
+    const stored = await loadDrinks()
+    expect(stored).toEqual([drink])
+  })
+
+  it('loadDrinks returns previous array', async () => {
+    const arr: DrinkEvent[] = [
+      { volumeMl: 50, abv: 0.1, date: new Date() }
+    ]
+    await saveDrinks(arr)
+    const loaded = await loadDrinks()
+    expect(loaded).toEqual(arr)
+  })
+})

--- a/sober-body-pwa/src/features/core/storage.ts
+++ b/sober-body-pwa/src/features/core/storage.ts
@@ -1,0 +1,26 @@
+import { get, set } from 'idb-keyval'
+import { type DrinkEvent } from './bac'
+
+export const KEYS = { drinks: 'sb_drinks', settings: 'sb_settings' } as const
+
+export async function loadDrinks(): Promise<DrinkEvent[]> {
+  return (await get(KEYS.drinks)) ?? []
+}
+
+export async function saveDrinks(arr: DrinkEvent[]): Promise<void> {
+  await set(KEYS.drinks, arr)
+}
+
+export interface Settings {
+  weightKg?: number
+  sex?: 'm' | 'f'
+  beta?: number
+}
+
+export async function loadSettings(): Promise<Settings | undefined> {
+  return (await get(KEYS.settings)) ?? undefined
+}
+
+export async function saveSettings(obj: Settings): Promise<void> {
+  await set(KEYS.settings, obj)
+}


### PR DESCRIPTION
## Summary
- add idb-keyval and fake-indexeddb packages
- persist drink log and settings via IndexedDB
- expose useDrinkLog hook with persistence
- update dashboard to use persisted drinks
- document storage layer in docs
- add tests for persistence

## Testing
- `npm run lint --silent`
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_685a2d63e4d4832b8a422e367b06f62f