### PR TITLE
Fix drink log persistence

### DIFF
--- a/sober-body-pwa/src/features/core/drink-context.test.tsx
+++ b/sober-body-pwa/src/features/core/drink-context.test.tsx
@@ -1,0 +1,58 @@
+import { render, screen, fireEvent, cleanup, waitFor } from '@testing-library/react'
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import 'fake-indexeddb/auto'
+import { DrinkLogProvider, useDrinkLog } from './drink-context'
+import { type DrinkEvent } from './bac'
+import { loadDrinks } from './storage'
+
+async function clearDB() {
+  const dbs = await indexedDB.databases?.()
+  if (dbs) await Promise.all(dbs.map(db => indexedDB.deleteDatabase(db.name!)))
+}
+
+function AddButton() {
+  const { addDrink } = useDrinkLog()
+  const drink: DrinkEvent = { volumeMl: 100, abv: 0.05, date: new Date() }
+  return <button onClick={() => addDrink(drink)}>Add</button>
+}
+
+function LogLength() {
+  const { drinks } = useDrinkLog()
+  return <div data-testid="length">{drinks.length}</div>
+}
+
+describe('DrinkLogProvider persistence', () => {
+  beforeEach(async () => {
+    await clearDB()
+  })
+  afterEach(() => cleanup())
+
+  it('restores drinks after remount', async () => {
+    const first = render(
+      <DrinkLogProvider>
+        <AddButton />
+        <LogLength />
+      </DrinkLogProvider>
+    )
+    // allow provider to load from storage
+    await new Promise(r => setTimeout(r, 20))
+    fireEvent.click(screen.getByRole('button', { name: /add/i }))
+    expect(screen.getByTestId('length').textContent).toBe('1')
+    // allow save effect to persist to IndexedDB
+    await waitFor(async () => {
+      const stored = await loadDrinks()
+      expect(stored.length).toBe(1)
+    })
+
+    first.unmount()
+
+    render(
+      <DrinkLogProvider>
+        <LogLength />
+      </DrinkLogProvider>
+    )
+    await waitFor(() => {
+      expect(screen.getByTestId('length').textContent).toBe('1')
+    })
+  })
+})

--- a/sober-body-pwa/src/features/core/drink-context.tsx
+++ b/sober-body-pwa/src/features/core/drink-context.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable react-refresh/only-export-components */
-import React, { createContext, useContext, useState, useEffect } from 'react'
+import React, { createContext, useContext, useState, useEffect, useRef } from 'react'
 import { type DrinkEvent } from './bac'
 import { loadDrinks, saveDrinks } from './storage'
 
@@ -13,13 +13,19 @@ const DrinkLogContext = createContext<DrinkLogValue | undefined>(undefined)
 
 export function DrinkLogProvider({ children }: { children: React.ReactNode }) {
   const [drinks, setDrinks] = useState<DrinkEvent[]>([])
+  const loaded = useRef(false)
 
   useEffect(() => {
-    loadDrinks().then(setDrinks)
+    loadDrinks().then(arr => {
+      setDrinks(arr)
+      loaded.current = true
+    })
   }, [])
 
   useEffect(() => {
-    saveDrinks(drinks)
+    if (loaded.current) {
+      saveDrinks(drinks)
+    }
   }, [drinks])
 
   const addDrink = (d: DrinkEvent) => setDrinks(prev => [...prev, d])


### PR DESCRIPTION
## Summary
- track when initial drink load completes
- delay saving until drinks are loaded
- test drink log persistence across provider remounts

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685a31437b08832b9cdd3fd1e3bd61c9