### PR TITLE
Add settings modal

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -18,7 +18,7 @@ Legend: **↑ = next up** · ✅ done · ⬜ open
 
 * ⬜ **feat(ui):** replace Vite splash with `<BacDashboard>` (hard‑coded demo)
 * ✅ **feat(ui):** DrinkButtons component (Beer 🍺 Wine 🍷 Shot 🥃)
-* ⬜ **feat(ui):** Settings modal (weight, sex, beta slider)
+* ✅ **feat(ui):** Settings modal (weight, sex, beta slider)
 * ✅ **feat(ui):** landing page & routing (#12)
 * ⬜ **feat(ui):** energetic landing hero
 

--- a/sober-body-pwa/src/App.tsx
+++ b/sober-body-pwa/src/App.tsx
@@ -3,15 +3,18 @@ import { Routes, Route } from 'react-router-dom'
 import BacDashboard from './components/BacDashboard'
 import LandingPage from './components/LandingPage'
 import { DrinkLogProvider } from './features/core/drink-context'
+import { SettingsProvider } from './features/core/settings-context'
 
 function App() {
   return (
-    <DrinkLogProvider>
-      <Routes>
-        <Route path="/" element={<LandingPage />} />
-        <Route path="/app" element={<BacDashboard />} />
-      </Routes>
-    </DrinkLogProvider>
+    <SettingsProvider>
+      <DrinkLogProvider>
+        <Routes>
+          <Route path="/" element={<LandingPage />} />
+          <Route path="/app" element={<BacDashboard />} />
+        </Routes>
+      </DrinkLogProvider>
+    </SettingsProvider>
   )
 }
 

--- a/sober-body-pwa/src/components/BacDashboard.tsx
+++ b/sober-body-pwa/src/components/BacDashboard.tsx
@@ -1,17 +1,27 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { estimateBAC, hoursToSober } from '../features/core/bac'
 import { useDrinkLog } from '../features/core/drink-context'
+import { useSettings } from '../features/core/settings-context'
 import DrinkButtons from './DrinkButtons'
+import SettingsModal from './SettingsModal'
 
 export default function BacDashboard() {
   const { drinks } = useDrinkLog()
-  const physiology = { weightKg: 70, sex: 'm' } as const
-  const bac = estimateBAC(drinks, physiology)
-  const sober = hoursToSober(bac, physiology)
+  const { settings } = useSettings()
+  const [open, setOpen] = useState(false)
+
+  const bac = estimateBAC(drinks, settings)
+  const sober = hoursToSober(bac, settings)
 
   return (
     <div>
-      <h1>BAC Dashboard</h1>
+      <header className="flex justify-between items-center mb-4">
+        <h1>BAC Dashboard</h1>
+        <button aria-label="settings" onClick={() => setOpen(true)}>
+          ⚙︎
+        </button>
+      </header>
+      <SettingsModal open={open} onClose={() => setOpen(false)} />
       <p>Current BAC: {bac.toFixed(3)}%</p>
       <p>Hours to sober: {sober.toFixed(1)}</p>
       <DrinkButtons />

--- a/sober-body-pwa/src/components/SettingsModal.tsx
+++ b/sober-body-pwa/src/components/SettingsModal.tsx
@@ -1,0 +1,71 @@
+import React, { useEffect, useState } from 'react'
+import { useSettings } from '../features/core/settings-context'
+export default function SettingsModal({
+  open,
+  onClose,
+}: { open: boolean; onClose: () => void }) {
+  const { settings, setSettings } = useSettings()
+  const [weight, setWeight] = useState(settings.weightKg)
+  const [sex, setSex] = useState(settings.sex)
+  const [beta, setBeta] = useState(settings.beta)
+  useEffect(() => {
+    if (open) {
+      setWeight(settings.weightKg)
+      setSex(settings.sex)
+      setBeta(settings.beta)
+    }
+  }, [open, settings])
+  const submit = () => {
+    setSettings({ weightKg: weight, sex, beta })
+    onClose()
+  }
+  if (!open) return null
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+      <div className="bg-white rounded-md p-4 w-72">
+        <h2 className="text-lg font-semibold mb-4">Settings</h2>
+        <label className="block mb-3 text-sm">
+          Weight: {weight} kg
+          <input
+            type="range"
+            min={40}
+            max={150}
+            value={weight}
+            onChange={e => setWeight(Number(e.target.value))}
+            className="w-full"
+          />
+        </label>
+        <div className="mb-3 flex gap-2 items-center">
+          Sex:
+          <button
+            className={`px-2 py-1 border rounded ${sex === 'm' ? 'bg-blue-500 text-white' : ''}`}
+            onClick={() => setSex('m')}
+          >
+            M
+          </button>
+          <button
+            className={`px-2 py-1 border rounded ${sex === 'f' ? 'bg-pink-500 text-white' : ''}`}
+            onClick={() => setSex('f')}
+          >
+            F
+          </button>
+        </div>
+        <label className="block mb-4 text-sm">
+          β: {beta.toFixed(3)}
+          <input
+            type="range"
+            min={0.01}
+            max={0.025}
+            step={0.001}
+            value={beta}
+            onChange={e => setBeta(Number(e.target.value))}
+            className="w-full"
+          />
+        </label>
+        <div className="text-right">
+          <button className="px-4 py-1 bg-blue-600 text-white rounded" onClick={submit}>Save</button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/sober-body-pwa/src/features/core/settings-context.test.tsx
+++ b/sober-body-pwa/src/features/core/settings-context.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen, fireEvent, cleanup, waitFor } from '@testing-library/react'
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { DEFAULT_BETA } from './bac'
+import { SettingsProvider, useSettings } from './settings-context'
+vi.mock('./storage', () => {
+  const store: { settings?: unknown } = {}
+  return {
+    loadSettings: vi.fn(() => Promise.resolve(store.settings)),
+    saveSettings: vi.fn((val: unknown) => {
+      store.settings = val
+      return Promise.resolve()
+    })
+  }
+})
+function WeightDisplay() {
+  const { settings } = useSettings()
+  return <div data-testid="weight">{settings.weightKg}</div>
+}
+function ChangeButton() {
+  const { setSettings } = useSettings()
+  return <button onClick={() => setSettings(s => ({ ...s, weightKg: 80 }))}>Change</button>
+}
+describe('SettingsProvider persistence', () => {
+  afterEach(() => cleanup())
+  it('persists changes via storage module', async () => {
+    const storage = await import('./storage')
+    const first = render(
+      <SettingsProvider>
+        <ChangeButton />
+        <WeightDisplay />
+      </SettingsProvider>
+    )
+    await waitFor(() => expect(storage.loadSettings).toHaveBeenCalled())
+    fireEvent.click(screen.getByRole('button', { name: /change/i }))
+    await waitFor(() => {
+      expect(storage.saveSettings).toHaveBeenCalledWith({ weightKg: 80, sex: 'm', beta: DEFAULT_BETA })
+    })
+    first.unmount()
+    render(
+      <SettingsProvider>
+        <WeightDisplay />
+      </SettingsProvider>
+    )
+    await waitFor(() => {
+      expect(screen.getByTestId('weight').textContent).toBe('80')
+    })
+  })
+})

--- a/sober-body-pwa/src/features/core/settings-context.tsx
+++ b/sober-body-pwa/src/features/core/settings-context.tsx
@@ -1,0 +1,39 @@
+/* eslint-disable react-refresh/only-export-components */
+import React, { createContext, useContext, useEffect, useRef, useState } from 'react'
+import { loadSettings, saveSettings, type Settings } from './storage'
+import { DEFAULT_BETA } from './bac'
+export interface SettingsValue {
+  settings: Required<Settings>
+  setSettings: React.Dispatch<React.SetStateAction<Required<Settings>>>
+}
+const DEFAULTS: Required<Settings> = {
+  weightKg: 70,
+  sex: 'm',
+  beta: DEFAULT_BETA
+}
+const SettingsContext = createContext<SettingsValue | undefined>(undefined)
+export function SettingsProvider({ children }: { children: React.ReactNode }) {
+  const [settings, setSettings] = useState<Required<Settings>>(DEFAULTS)
+  const loaded = useRef(false)
+  useEffect(() => {
+    loadSettings().then(stored => {
+      if (stored) setSettings(prev => ({ ...prev, ...stored }))
+      loaded.current = true
+    })
+  }, [])
+  useEffect(() => {
+    if (loaded.current) {
+      saveSettings(settings)
+    }
+  }, [settings])
+  return (
+    <SettingsContext.Provider value={{ settings, setSettings }}>
+      {children}
+    </SettingsContext.Provider>
+  )
+}
+export function useSettings() {
+  const ctx = useContext(SettingsContext)
+  if (!ctx) throw new Error('useSettings must be used within SettingsProvider')
+  return ctx
+}


### PR DESCRIPTION
## Summary
- create SettingsProvider context with defaults and persistence
- add SettingsModal component with sliders for weight and β, and sex toggle
- integrate settings in BacDashboard with ⚙︎ icon
- wrap app with provider and mark backlog item
- add tests for settings persistence

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685b4e99ca70832ba9925c4620f7dc48