### PR TITLE
Add engagement mini-game stub

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -31,6 +31,10 @@ Legend: **↑ = next up** · ✅ done · ⬜ open
 
 * ⬜ **feat(group):** stub WebSocket host + QR join flow
 
+## Engagement & Games
+
+* ⬜ **feat(games):** Pronunciation Challenge mini-game (WP‑5)
+
 ## Docs & Governance
 
 * ⬜ **docs:** WP‑1 compliant core (algorithms & privacy) first draft

--- a/docs/whitepapers/wp5_engagement_modules.md
+++ b/docs/whitepapers/wp5_engagement_modules.md
@@ -1,0 +1,17 @@
+# WP-5 Engagement Modules
+
+**Version 0.1 · Draft**
+**Date:** 23 Jun 2025
+
+This paper outlines optional games that boost user stickiness while keeping the compliant core untouched. All modules communicate via the Event Bus.
+
+## Planned Mini-Games
+
+- **Reaction Tap** – baseline reflex check.
+- **Stroop Swipe** – colour-word confusion task.
+- **Pronunciation Challenge** – tongue‑twister using SpeechRecognition. Emits `PRONUN_SCORE` events for later ML analysis.
+
+Modules are loaded by policy and may be disabled in strict profiles.
+
+---
+*End of file*

--- a/sober-body-pwa/src/components/BacDashboard.tsx
+++ b/sober-body-pwa/src/components/BacDashboard.tsx
@@ -4,11 +4,13 @@ import { useDrinkLog } from '../features/core/drink-context'
 import { useSettings } from '../features/core/settings-context'
 import DrinkButtons from './DrinkButtons'
 import SettingsModal from './SettingsModal'
+import PronunciationChallenge from '../features/games/PronunciationChallenge'
 
 export default function BacDashboard() {
   const { drinks } = useDrinkLog()
   const { settings } = useSettings()
   const [open, setOpen] = useState(false)
+  const [game, setGame] = useState(false)
 
   const bac = estimateBAC(drinks, settings)
   const sober = hoursToSober(bac, settings)
@@ -20,8 +22,16 @@ export default function BacDashboard() {
         <button aria-label="settings" onClick={() => setOpen(true)}>
           ⚙︎
         </button>
+        <button aria-label="play game" onClick={() => setGame(true)}>
+          🎮
+        </button>
       </header>
       <SettingsModal open={open} onClose={() => setOpen(false)} />
+      {game && (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+          <PronunciationChallenge onClose={() => setGame(false)} />
+        </div>
+      )}
       <p>Current BAC: {bac.toFixed(3)}%</p>
       <p>Hours to sober: {sober.toFixed(1)}</p>
       <DrinkButtons />

--- a/sober-body-pwa/src/features/core/bus.ts
+++ b/sober-body-pwa/src/features/core/bus.ts
@@ -1,0 +1,12 @@
+export type BusTopic = 'PRONUN_SCORE'
+export type BusProfile = 'strict' | 'standard' | 'offline_relaxed'
+
+export interface BusEnvelope<T> {
+  topic: BusTopic
+  payload: T
+  profile: BusProfile
+}
+
+export function emit<T>(envelope: BusEnvelope<T>): void {
+  window.dispatchEvent(new CustomEvent(envelope.topic, { detail: envelope }))
+}

--- a/sober-body-pwa/src/features/games/PronunciationChallenge.tsx
+++ b/sober-body-pwa/src/features/games/PronunciationChallenge.tsx
@@ -1,0 +1,85 @@
+import React, { useState, useRef } from 'react'
+import confetti from 'canvas-confetti'
+import { phrases, type TwisterPhrase } from './twister-phrases'
+import { emit } from '../core/bus'
+
+function levenshtein(a: string, b: string): number {
+  const dp = Array.from({ length: a.length + 1 }, (_, i) => i)
+  for (let i = 1; i <= b.length; i++) {
+    let prev = i - 1
+    dp[0] = i
+    for (let j = 1; j <= a.length; j++) {
+      const temp = dp[j]
+      dp[j] = Math.min(dp[j] + 1, dp[j - 1] + 1, prev + (a[j - 1] === b[i - 1] ? 0 : 1))
+      prev = temp
+    }
+  }
+  return dp[a.length]
+}
+
+function randomPhrase(): TwisterPhrase {
+  return phrases[Math.floor(Math.random() * phrases.length)]
+}
+
+export default function PronunciationChallenge({ onClose }: { onClose: () => void }) {
+  const [phrase, setPhrase] = useState<TwisterPhrase>(randomPhrase())
+  const [transcript, setTranscript] = useState('')
+  const [score, setScore] = useState<number | null>(null)
+  const transcriptRef = useRef('')
+
+  const play = () => {
+    const u = new SpeechSynthesisUtterance(phrase.text)
+    u.lang = phrase.locale
+    speechSynthesis.speak(u)
+  }
+
+  const start = () => {
+    const w = window as unknown as {
+      SpeechRecognition?: new () => SpeechRecognition
+      webkitSpeechRecognition?: new () => SpeechRecognition
+    }
+    const Rec = w.SpeechRecognition || w.webkitSpeechRecognition
+    if (!Rec) return
+    const r: SpeechRecognition = new Rec()
+    r.lang = phrase.locale
+    r.onresult = (e: SpeechRecognitionEvent) => {
+      transcriptRef.current = e.results[0][0].transcript
+      setTranscript(transcriptRef.current)
+    }
+    r.onend = () => {
+      const dist = levenshtein(transcriptRef.current.toLowerCase(), phrase.text.toLowerCase())
+      const maxLen = Math.max(transcriptRef.current.length, phrase.text.length)
+      const s = Math.round((1 - dist / maxLen) * 100)
+      setScore(s)
+      emit({ topic: 'PRONUN_SCORE', payload: { phrase: phrase.text, transcript: transcriptRef.current, score: s }, profile: 'standard' })
+      if (s >= 80) confetti({ particleCount: 80, spread: 60 })
+    }
+    r.start()
+    setTimeout(() => r.stop(), 4000)
+  }
+
+  const next = () => {
+    setPhrase(randomPhrase())
+    setTranscript('')
+    setScore(null)
+  }
+
+  return (
+    <div className="bg-white rounded-md p-4 w-72">
+      <h3 className="font-semibold mb-2">Tongue Twister</h3>
+      <p className="mb-2">“{phrase.text}”</p>
+      <div className="flex gap-2 mb-2">
+        <button onClick={play} aria-label="play">▶️</button>
+        <button onClick={start} aria-label="record">🎙️</button>
+        <button onClick={onClose} aria-label="close">✖︎</button>
+      </div>
+      {score !== null && (
+        <div className="mt-2 text-sm">
+          <p>Heard: {transcript}</p>
+          <p>Score: {score}%</p>
+          <button className="mt-2" onClick={next}>Next</button>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/sober-body-pwa/src/features/games/__tests__/PronunciationChallenge.test.tsx
+++ b/sober-body-pwa/src/features/games/__tests__/PronunciationChallenge.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import PronunciationChallenge from '../PronunciationChallenge'
+import { phrases } from '../twister-phrases'
+
+vi.mock('canvas-confetti', () => ({ default: vi.fn() }))
+
+class MockSpeechRecognition {
+  lang = ''
+  onresult: ((e: SpeechRecognitionEvent) => void) | null = null
+  onend: (() => void) | null = null
+  start() {
+    this.onresult?.({ results: [[{ transcript: phrases[0].text }]] })
+    this.onend?.()
+  }
+  stop() {}
+}
+
+globalThis.SpeechRecognition = MockSpeechRecognition as unknown as typeof SpeechRecognition
+;(globalThis as unknown as { webkitSpeechRecognition?: typeof SpeechRecognition }).webkitSpeechRecognition = MockSpeechRecognition as unknown as typeof SpeechRecognition
+
+afterEach(() => vi.restoreAllMocks())
+
+describe('PronunciationChallenge', () => {
+  it('scores 100% for exact match', async () => {
+    vi.spyOn(Math, 'random').mockReturnValue(0)
+    render(<PronunciationChallenge onClose={() => {}} />)
+    fireEvent.click(screen.getByLabelText('record'))
+    expect(await screen.findByText(/Score: 100%/)).toBeTruthy()
+  })
+})

--- a/sober-body-pwa/src/features/games/twister-phrases.ts
+++ b/sober-body-pwa/src/features/games/twister-phrases.ts
@@ -1,0 +1,17 @@
+export interface TwisterPhrase {
+  text: string
+  locale: string
+}
+
+export const phrases: TwisterPhrase[] = [
+  { text: 'She sells sea shells by the sea shore', locale: 'en-US' },
+  { text: 'How can a clam cram in a clean cream can', locale: 'en-US' },
+  { text: 'I scream you scream we all scream for ice cream', locale: 'en-US' },
+  { text: 'Red lorry yellow lorry', locale: 'en-GB' },
+  { text: 'Peter Piper picked a peck of pickled peppers', locale: 'en-US' },
+  { text: 'Fuzzy Wuzzy was a bear Fuzzy Wuzzy had no hair', locale: 'en-US' },
+  { text: 'Black background brown background', locale: 'en-GB' },
+  { text: 'Near an ear a nearer ear a nearly eerie ear', locale: 'en-US' },
+  { text: 'Truly rural', locale: 'en-GB' },
+  { text: 'Toy boat', locale: 'en-US' }
+]


### PR DESCRIPTION
## Summary
- add Engagement & Games section to backlog
- outline WP-5 Engagement Modules white‑paper
- stub event bus
- implement PronunciationChallenge mini-game
- add button in dashboard to launch game
- include unit test mocking SpeechRecognition

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685b5299b81c832b860002055e0bfbf8