### PR TITLE
Handle pronunciation errors

### DIFF
--- a/sober-body-pwa/src/features/games/__tests__/PronunciationChallenge.test.tsx
+++ b/sober-body-pwa/src/features/games/__tests__/PronunciationChallenge.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen, fireEvent, cleanup } from '@testing-library/react'
 import { describe, it, expect, vi, afterEach } from 'vitest'
 import PronunciationChallenge from '../PronunciationChallenge'
 import { phrases } from '../twister-phrases'
@@ -16,16 +16,40 @@ class MockSpeechRecognition {
   stop() {}
 }
 
-globalThis.SpeechRecognition = MockSpeechRecognition as unknown as typeof SpeechRecognition
-;(globalThis as unknown as { webkitSpeechRecognition?: typeof SpeechRecognition }).webkitSpeechRecognition = MockSpeechRecognition as unknown as typeof SpeechRecognition
-
-afterEach(() => vi.restoreAllMocks())
+afterEach(() => {
+  vi.restoreAllMocks()
+  delete (globalThis as Record<string, unknown>).SpeechRecognition
+  delete (globalThis as Record<string, unknown>).webkitSpeechRecognition
+  ;(navigator as unknown as Record<string, unknown>).permissions = undefined
+  cleanup()
+})
 
 describe('PronunciationChallenge', () => {
   it('scores 100% for exact match', async () => {
+    globalThis.SpeechRecognition = MockSpeechRecognition as unknown as typeof SpeechRecognition
+    ;(globalThis as unknown as { webkitSpeechRecognition?: typeof SpeechRecognition }).webkitSpeechRecognition =
+      MockSpeechRecognition as unknown as typeof SpeechRecognition
     vi.spyOn(Math, 'random').mockReturnValue(0)
     render(<PronunciationChallenge onClose={() => {}} />)
     fireEvent.click(screen.getByLabelText('record'))
     expect(await screen.findByText(/Score: 100%/)).toBeTruthy()
+  })
+
+  it('shows error when speech recognition is unavailable', async () => {
+    render(<PronunciationChallenge onClose={() => {}} />)
+    fireEvent.click(screen.getByLabelText('record'))
+    expect(await screen.findByText(/Speech recognition is unavailable/i)).toBeTruthy()
+  })
+
+  it('shows error when microphone permission denied', async () => {
+    globalThis.SpeechRecognition = MockSpeechRecognition as unknown as typeof SpeechRecognition
+    ;(globalThis as unknown as { webkitSpeechRecognition?: typeof SpeechRecognition }).webkitSpeechRecognition =
+      MockSpeechRecognition as unknown as typeof SpeechRecognition
+    ;(navigator as unknown as Record<string, unknown>).permissions = {
+      query: vi.fn().mockResolvedValue({ state: 'denied' }),
+    }
+    render(<PronunciationChallenge onClose={() => {}} />)
+    fireEvent.click(screen.getByLabelText('record'))
+    expect(await screen.findByText(/Microphone access denied/i)).toBeTruthy()
   })
 })


### PR DESCRIPTION
## Summary
- add error state and permission checks for speech recognition
- show error message in PronunciationChallenge UI
- test speech recognition errors

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685b583ffe28832bb5532bdd0a376cf2