### PR TITLE
Improve Pronunciation Challenge UI

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -34,6 +34,7 @@ Legend: **↑ = next up** · ✅ done · ⬜ open
 ## Engagement & Games
 
 * ⬜ **feat(games):** Pronunciation Challenge mini-game (WP‑5)
+* ⬜ **feat(games):** improve Pronunciation UI (record/next flow, verdicts)
 
 ## Docs & Governance
 

--- a/sober-body-pwa/src/features/games/__tests__/PronunciationChallenge.test.tsx
+++ b/sober-body-pwa/src/features/games/__tests__/PronunciationChallenge.test.tsx
@@ -52,4 +52,17 @@ describe('PronunciationChallenge', () => {
     fireEvent.click(screen.getByLabelText('record'))
     expect(await screen.findByText(/Microphone access denied/i)).toBeTruthy()
   })
+
+  it('enables Next button after scoring', async () => {
+    globalThis.SpeechRecognition = MockSpeechRecognition as unknown as typeof SpeechRecognition
+    ;(globalThis as unknown as { webkitSpeechRecognition?: typeof SpeechRecognition }).webkitSpeechRecognition =
+      MockSpeechRecognition as unknown as typeof SpeechRecognition
+    vi.spyOn(Math, 'random').mockReturnValue(0)
+    render(<PronunciationChallenge onClose={() => {}} />)
+    const nextBtn = screen.getByLabelText('next')
+    expect(nextBtn.hasAttribute('disabled')).toBe(true)
+    fireEvent.click(screen.getByLabelText('record'))
+    await screen.findByText(/Score: 100%/)
+    expect(nextBtn.hasAttribute('disabled')).toBe(false)
+  })
 })


### PR DESCRIPTION
## Summary
- redesign mini-game controls
- add verdict messages and disable Next until scoring
- add backlog bullet for improved UI
- test Next button state

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685b5af12f64832b9685d29503b15f93