### PR TITLE
feat/games-portuguese-twister

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -35,6 +35,7 @@ Legend: **↑ = next up** · ✅ done · ⬜ open
 
 * ⬜ **feat(games):** Pronunciation Challenge mini-game (WP‑5)
 * ⬜ **feat(games):** improve Pronunciation UI (record/next flow, verdicts)
+* ⬜ **feat(games):** Portuguese tongue-twister deck & lang switcher
 
 ## Docs & Governance
 

--- a/sober-body-pwa/src/features/games/PronunciationChallenge.tsx
+++ b/sober-body-pwa/src/features/games/PronunciationChallenge.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef } from 'react'
+import React, { useState, useRef, useEffect } from 'react'
 import confetti from 'canvas-confetti'
 import { phrases, type TwisterPhrase } from './twister-phrases'
 import { emit } from '../core/bus'
@@ -17,18 +17,24 @@ function levenshtein(a: string, b: string): number {
   return dp[a.length]
 }
 
-function randomPhrase(): TwisterPhrase {
-  return phrases[Math.floor(Math.random() * phrases.length)]
+function randomPhrase(locale: string): TwisterPhrase {
+  const opts = phrases.filter((p) => p.locale === locale)
+  return opts[Math.floor(Math.random() * opts.length)]
 }
 
 export default function PronunciationChallenge({ onClose }: { onClose: () => void }) {
-  const [phrase, setPhrase] = useState<TwisterPhrase>(randomPhrase())
+  const [lang, setLang] = useState<'en-US' | 'pt-BR'>('en-US')
+  const [phrase, setPhrase] = useState<TwisterPhrase>(randomPhrase('en-US'))
   const [transcript, setTranscript] = useState('')
   const [score, setScore] = useState<number | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [recording, setRecording] = useState(false)
   const recRef = useRef<SpeechRecognition | null>(null)
   const transcriptRef = useRef('')
+
+  useEffect(() => {
+    setPhrase(randomPhrase(lang))
+  }, [lang])
 
   const play = () => {
     const u = new SpeechSynthesisUtterance(phrase.text)
@@ -87,7 +93,7 @@ export default function PronunciationChallenge({ onClose }: { onClose: () => voi
   }
 
   const next = () => {
-    setPhrase(randomPhrase())
+    setPhrase(randomPhrase(lang))
     setTranscript('')
     setScore(null)
     setError(null)
@@ -97,6 +103,22 @@ export default function PronunciationChallenge({ onClose }: { onClose: () => voi
   return (
     <div className="bg-white rounded-md p-4 w-72">
       <h3 className="font-semibold mb-2">Tongue Twister</h3>
+      <div className="flex gap-2 mb-2">
+        <button
+          aria-label="en-US"
+          onClick={() => setLang('en-US')}
+          className={lang === 'en-US' ? 'font-bold' : ''}
+        >
+          🇺🇸 EN
+        </button>
+        <button
+          aria-label="pt-BR"
+          onClick={() => setLang('pt-BR')}
+          className={lang === 'pt-BR' ? 'font-bold' : ''}
+        >
+          🇧🇷 PT
+        </button>
+      </div>
       <p className="mb-2">“{phrase.text}”</p>
       <div className="flex gap-3 mt-4">
         <button

--- a/sober-body-pwa/src/features/games/__tests__/PronunciationChallenge.test.tsx
+++ b/sober-body-pwa/src/features/games/__tests__/PronunciationChallenge.test.tsx
@@ -3,6 +3,8 @@ import { describe, it, expect, vi, afterEach } from 'vitest'
 import PronunciationChallenge from '../PronunciationChallenge'
 import { phrases } from '../twister-phrases'
 
+let usedLang = ''
+
 vi.mock('canvas-confetti', () => ({ default: vi.fn() }))
 
 class MockSpeechRecognition {
@@ -10,6 +12,7 @@ class MockSpeechRecognition {
   onresult: ((e: SpeechRecognitionEvent) => void) | null = null
   onend: (() => void) | null = null
   start() {
+    usedLang = this.lang
     this.onresult?.({ results: [[{ transcript: phrases[0].text }]] })
     this.onend?.()
   }
@@ -64,5 +67,16 @@ describe('PronunciationChallenge', () => {
     fireEvent.click(screen.getByLabelText('record'))
     await screen.findByText(/Score: 100%/)
     expect(nextBtn.hasAttribute('disabled')).toBe(false)
+  })
+
+  it('uses pt-BR when PT button clicked', async () => {
+    globalThis.SpeechRecognition = MockSpeechRecognition as unknown as typeof SpeechRecognition
+    ;(globalThis as unknown as { webkitSpeechRecognition?: typeof SpeechRecognition }).webkitSpeechRecognition =
+      MockSpeechRecognition as unknown as typeof SpeechRecognition
+    vi.spyOn(Math, 'random').mockReturnValue(0)
+    render(<PronunciationChallenge onClose={() => {}} />)
+    fireEvent.click(screen.getByLabelText('pt-BR'))
+    fireEvent.click(screen.getByLabelText('record'))
+    expect(usedLang).toBe('pt-BR')
   })
 })

--- a/sober-body-pwa/src/features/games/twister-phrases.ts
+++ b/sober-body-pwa/src/features/games/twister-phrases.ts
@@ -13,5 +13,10 @@ export const phrases: TwisterPhrase[] = [
   { text: 'Black background brown background', locale: 'en-GB' },
   { text: 'Near an ear a nearer ear a nearly eerie ear', locale: 'en-US' },
   { text: 'Truly rural', locale: 'en-GB' },
-  { text: 'Toy boat', locale: 'en-US' }
+  { text: 'Toy boat', locale: 'en-US' },
+  { text: 'Três pratos de trigo para três tigres tristes', locale: 'pt-BR' },
+  { text: 'O rato roeu a roupa do rei de Roma', locale: 'pt-BR' },
+  { text: 'Bagre branco, branco bagre', locale: 'pt-BR' },
+  { text: 'Casa suja, chão sujo', locale: 'pt-BR' },
+  { text: 'Paralelepípedo', locale: 'pt-BR' }
 ]


### PR DESCRIPTION
## Summary
- add Brazilian Portuguese tongue twister phrases
- support language toggle in `PronunciationChallenge`
- test the new PT button behaviour
- track backlog item for the lang switcher

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685b62e99740832b9ff9fce9a2ecbbfd