### PR TITLE
Add PronunciationCoach component with speech mocks

### DIFF
--- a/sober-body-pwa/global.d.ts
+++ b/sober-body-pwa/global.d.ts
@@ -1,0 +1,2 @@
+declare const SpeechRecognition: new () => SpeechRecognition
+declare const webkitSpeechRecognition: new () => SpeechRecognition

--- a/sober-body-pwa/package-lock.json
+++ b/sober-body-pwa/package-lock.json
@@ -27,6 +27,7 @@
         "eslint-plugin-react-hooks": "^5.2.0",
         "eslint-plugin-react-refresh": "^0.4.19",
         "fake-indexeddb": "^5.0.2",
+        "fast-levenshtein": "^3.0.0",
         "globals": "^16.0.0",
         "jsdom": "^26.1.0",
         "postcss": "^8.5.6",
@@ -3113,10 +3114,24 @@
       "dev": true
     },
     "node_modules/fast-levenshtein": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
-      "dev": true
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-3.0.0.tgz",
+      "integrity": "sha512-hKKNajm46uNmTlhHSyZkmToAc56uZJwYq7yrciZjqOxnlfQwERDQJmHPUp7m1m9wx8vgOe8IaCKZ5Kv2k1DdCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fastest-levenshtein": "^1.0.7"
+      }
+    },
+    "node_modules/fastest-levenshtein": {
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
+      "integrity": "sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.9.1"
+      }
     },
     "node_modules/fastq": {
       "version": "1.19.1",
@@ -4183,6 +4198,13 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/optionator/node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/p-limit": {
       "version": "3.1.0",

--- a/sober-body-pwa/package.json
+++ b/sober-body-pwa/package.json
@@ -30,6 +30,7 @@
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.19",
     "fake-indexeddb": "^5.0.2",
+    "fast-levenshtein": "^3.0.0",
     "globals": "^16.0.0",
     "jsdom": "^26.1.0",
     "postcss": "^8.5.6",

--- a/sober-body-pwa/src/features/games/PronunciationCoach.tsx
+++ b/sober-body-pwa/src/features/games/PronunciationCoach.tsx
@@ -1,0 +1,70 @@
+import React, { useRef, useState, useEffect } from 'react'
+import confetti from 'canvas-confetti'
+import { score as scorePhrase } from './scoring/levenshtein'
+
+export interface PronunciationCoachProps {
+  phrase: string
+  locale: string
+  maxSecs?: number
+  onScore?: (r: { score: number; transcript: string; millis: number }) => void
+}
+
+export default function PronunciationCoach({ phrase, locale, maxSecs, onScore }: PronunciationCoachProps) {
+  const [recording, setRecording] = useState(false)
+  const [result, setResult] = useState<number | null>(null)
+  const recRef = useRef<SpeechRecognition | null>(null)
+  const tRef = useRef('')
+  const startTime = useRef(0)
+  const dur = useRef(0)
+
+  const limit = Math.min(6000, Math.max(2000, Math.round((maxSecs ?? phrase.length / 8) * 1000)))
+
+  useEffect(() => () => recRef.current?.stop(), [])
+
+  const play = () => {
+    const u = new SpeechSynthesisUtterance(phrase)
+    const voice = speechSynthesis.getVoices().find(v => v.lang === locale)
+    if (voice) u.voice = voice
+    u.lang = locale
+    speechSynthesis.speak(u)
+  }
+
+  const start = async () => {
+    const w = window as unknown as {
+      SpeechRecognition?: new () => SpeechRecognition
+      webkitSpeechRecognition?: new () => SpeechRecognition
+    }
+    const Rec = w.SpeechRecognition || w.webkitSpeechRecognition
+    if (!Rec) return
+    await navigator.mediaDevices.getUserMedia({ audio: true })
+    const r: SpeechRecognition = new Rec()
+    recRef.current = r
+    r.lang = locale
+    r.onresult = e => {
+      tRef.current = e.results[0][0].transcript
+    }
+    r.onend = () => {
+      dur.current = Date.now() - startTime.current
+      const s = scorePhrase(phrase, tRef.current)
+      setResult(s)
+      if (s >= 80) confetti({ particleCount: 80, spread: 55 })
+      onScore?.({ score: s, transcript: tRef.current, millis: dur.current })
+      setRecording(false)
+    }
+    startTime.current = Date.now()
+    r.start()
+    setRecording(true)
+    setTimeout(() => r.stop(), limit)
+  }
+
+  return (
+    <div className="space-x-2">
+      <button onClick={play}>▶ Play</button>
+      <button
+        disabled={!(('SpeechRecognition' in window) || ('webkitSpeechRecognition' in window))}
+        onClick={recording ? () => recRef.current?.stop() : start}
+      >{recording ? '■ Stop' : '⏺ Record'}</button>
+      {result !== null && <span>Score {result}%</span>}
+    </div>
+  )
+}

--- a/sober-body-pwa/src/features/games/__tests__/pronun-coach.test.tsx
+++ b/sober-body-pwa/src/features/games/__tests__/pronun-coach.test.tsx
@@ -1,0 +1,53 @@
+import { render, fireEvent, cleanup } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import PronunciationCoach from '../PronunciationCoach'
+import { installSpeechMocks } from '../../../../test/utils/mockSpeech.ts'
+
+vi.mock('canvas-confetti', () => ({ default: vi.fn() }))
+
+vi.useFakeTimers()
+
+describe('PronunciationCoach', () => {
+  beforeEach(() => {
+    installSpeechMocks()
+  })
+  afterEach(() => {
+    vi.clearAllTimers()
+    cleanup()
+  })
+
+  it('counts perfect score', async () => {
+    const onScore = vi.fn()
+    const { getByText } = render(
+      <PronunciationCoach phrase="mock transcript" locale="en-US" onScore={onScore} />
+    )
+    fireEvent.click(getByText('⏺ Record'))
+    await vi.runAllTimersAsync()
+    await Promise.resolve()
+    await vi.runAllTicks()
+    expect(onScore).toHaveBeenCalled()
+    expect(onScore.mock.calls[0][0].score).toBe(100)
+  })
+
+  it('clamps recording to maxSecs', async () => {
+    const onScore = vi.fn()
+    render(
+      <PronunciationCoach phrase="a very long phrase here" locale="en-US" maxSecs={2} onScore={onScore} />
+    )
+    fireEvent.click(document.querySelector('button:nth-child(2)')!)
+    await vi.runAllTimersAsync()
+    await Promise.resolve()
+    await vi.runAllTicks()
+    expect(onScore.mock.calls[0][0].millis).toBeLessThanOrEqual(2000)
+  })
+
+  it('disables record when API missing', () => {
+    delete (globalThis as Record<string, unknown>).SpeechRecognition
+    delete (globalThis as Record<string, unknown>).webkitSpeechRecognition
+    const { getByText } = render(
+      <PronunciationCoach phrase="x" locale="en-US" />
+    )
+    const btn = getByText('⏺ Record') as HTMLButtonElement
+    expect(btn.disabled).toBe(true)
+  })
+})

--- a/sober-body-pwa/src/features/games/scoring/levenshtein.ts
+++ b/sober-body-pwa/src/features/games/scoring/levenshtein.ts
@@ -1,0 +1,8 @@
+import levenshtein from 'fast-levenshtein'
+
+export function score(ref: string, transcript: string): number {
+  const dist = levenshtein.get(ref.toLowerCase(), transcript.toLowerCase())
+  const maxLen = Math.max(ref.length, transcript.length)
+  const pct = 100 * (1 - dist / maxLen)
+  return Math.max(0, Math.min(100, Math.round(pct)))
+}

--- a/sober-body-pwa/test/utils/mockSpeech.ts
+++ b/sober-body-pwa/test/utils/mockSpeech.ts
@@ -1,0 +1,30 @@
+import { vi } from 'vitest'
+
+export function installSpeechMocks() {
+  globalThis.speechSynthesis = {
+    speak: vi.fn(),
+    cancel: vi.fn(),
+    getVoices: () => [{ name: 'MockVoice', lang: 'en-US' }],
+  } as unknown as SpeechSynthesis
+
+  class MockRecognition extends EventTarget {
+    lang = 'en-US'
+    start = vi.fn(() => {
+      queueMicrotask(() => {
+        const evt = new Event('result') as SpeechRecognitionEvent
+        Object.defineProperty(evt, 'results', {
+          value: [[{ transcript: 'mock transcript', confidence: 1 }]],
+        })
+        this.onresult?.(evt)
+        this.onend?.()
+      })
+    })
+    stop = vi.fn()
+  }
+  ;(globalThis as Record<string, unknown>).SpeechRecognition = MockRecognition
+  ;(globalThis as Record<string, unknown>).webkitSpeechRecognition = MockRecognition
+
+  navigator.mediaDevices = {
+    getUserMedia: vi.fn().mockResolvedValue({} as MediaStream),
+  } as MediaDevices
+}


### PR DESCRIPTION
## Summary
- create reusable `PronunciationCoach` for any phrase and locale
- compute pronunciation score with Levenshtein helper
- add speech API mocks for unit tests
- write tests verifying score, recording limit and disabled state
- declare SpeechRecognition globals

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685b6616c5b0832b99a67bb7ee800258