### PR TITLE
fix(ui): global ModalProvider

### DIFF
--- a/sober-body-pwa/src/components/BacDashboard.tsx
+++ b/sober-body-pwa/src/components/BacDashboard.tsx
@@ -1,16 +1,16 @@
-import React, { useState } from 'react'
+import React from 'react'
 import { estimateBAC, hoursToSober } from '../features/core/bac'
 import { useDrinkLog } from '../features/core/drink-context'
 import { useSettings } from '../features/core/settings-context'
 import DrinkButtons from './DrinkButtons'
 import SettingsModal from './SettingsModal'
-import PronunciationChallenge from '../features/games/PronunciationChallenge'
+import PronunciationModal from './PronunciationModal'
+import { useModal } from './ModalContext'
 
 export default function BacDashboard() {
   const { drinks } = useDrinkLog()
   const { settings } = useSettings()
-  const [open, setOpen] = useState(false)
-  const [game, setGame] = useState(false)
+  const { active, open, close } = useModal()
 
   const bac = estimateBAC(drinks, settings)
   const sober = hoursToSober(bac, settings)
@@ -19,19 +19,15 @@ export default function BacDashboard() {
     <div>
       <header className="flex justify-between items-center mb-4">
         <h1>BAC Dashboard</h1>
-        <button aria-label="settings" onClick={() => setOpen(true)}>
+        <button aria-label="settings" onClick={() => open('settings')}>
           ⚙︎
         </button>
-        <button aria-label="play game" onClick={() => setGame(true)}>
+        <button aria-label="play game" onClick={() => open('twister')}>
           🎮
         </button>
       </header>
-      <SettingsModal open={open} onClose={() => setOpen(false)} />
-      {game && (
-        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
-          <PronunciationChallenge onClose={() => setGame(false)} />
-        </div>
-      )}
+      <SettingsModal open={active === 'settings'} onClose={close} />
+      <PronunciationModal open={active === 'twister'} onClose={close} />
       <p>Current BAC: {bac.toFixed(3)}%</p>
       <p>Hours to sober: {sober.toFixed(1)}</p>
       <DrinkButtons />

--- a/sober-body-pwa/src/components/ModalContext.test.tsx
+++ b/sober-body-pwa/src/components/ModalContext.test.tsx
@@ -1,0 +1,37 @@
+import { render, fireEvent, screen, cleanup } from '@testing-library/react'
+import { describe, it, expect, afterEach } from 'vitest'
+import 'fake-indexeddb/auto'
+import SettingsModal from './SettingsModal'
+import PronunciationModal from './PronunciationModal'
+import { ModalProvider, useModal } from './ModalContext'
+import { SettingsProvider } from '../features/core/settings-context'
+
+function Tester() {
+  const { active, open, close } = useModal()
+  return (
+    <div>
+      <button onClick={() => open('settings')}>open settings</button>
+      <button onClick={() => open('twister')}>open twister</button>
+      <SettingsModal open={active === 'settings'} onClose={close} />
+      <PronunciationModal open={active === 'twister'} onClose={close} />
+    </div>
+  )
+}
+
+describe('ModalProvider', () => {
+  afterEach(() => cleanup())
+  it('only one modal visible at a time', () => {
+    render(
+      <SettingsProvider>
+        <ModalProvider>
+          <Tester />
+        </ModalProvider>
+      </SettingsProvider>
+    )
+    fireEvent.click(screen.getByText('open settings'))
+    expect(screen.getByText('Settings')).toBeTruthy()
+    fireEvent.click(screen.getByText('open twister'))
+    expect(screen.queryByText('Settings')).toBeNull()
+    expect(screen.getByText('Tongue Twister')).toBeTruthy()
+  })
+})

--- a/sober-body-pwa/src/components/ModalContext.tsx
+++ b/sober-body-pwa/src/components/ModalContext.tsx
@@ -1,0 +1,22 @@
+import React, { useState } from 'react'
+
+type ModalType = 'none' | 'settings' | 'twister'
+
+const ModalContext = React.createContext<{
+  active: ModalType
+  open: (m: ModalType) => void
+  close: () => void
+}>({ active: 'none', open: () => {}, close: () => {} })
+
+export const ModalProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [active, setActive] = useState<ModalType>('none')
+  const open = (m: ModalType) => setActive(m)
+  const close = () => setActive('none')
+  return (
+    <ModalContext.Provider value={{ active, open, close }}>
+      {children}
+    </ModalContext.Provider>
+  )
+}
+
+export const useModal = () => React.useContext(ModalContext)

--- a/sober-body-pwa/src/components/PronunciationModal.tsx
+++ b/sober-body-pwa/src/components/PronunciationModal.tsx
@@ -1,0 +1,13 @@
+import PronunciationChallenge from '../features/games/PronunciationChallenge'
+
+export default function PronunciationModal({
+  open,
+  onClose,
+}: { open: boolean; onClose: () => void }) {
+  if (!open) return null
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+      <PronunciationChallenge onClose={onClose} />
+    </div>
+  )
+}

--- a/sober-body-pwa/src/main.tsx
+++ b/sober-body-pwa/src/main.tsx
@@ -3,11 +3,14 @@ import { createRoot } from 'react-dom/client'
 import { BrowserRouter } from 'react-router-dom'
 import './index.css'
 import App from './App.tsx'
+import { ModalProvider } from './components/ModalContext'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <BrowserRouter>
-      <App />
+      <ModalProvider>
+        <App />
+      </ModalProvider>
     </BrowserRouter>
   </StrictMode>,
 )


### PR DESCRIPTION
## Summary
- create `ModalContext` to manage open dialogs globally
- add `PronunciationModal` wrapper
- use modal context in `BacDashboard`
- wrap app in `ModalProvider`
- test modal context behaviour

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685d95f4b7f0832baee288ba2e401227