### PR TITLE
feat(ui): refine coach layout

### DIFF
--- a/apps/sober-body/src/components/LineNavigator.tsx
+++ b/apps/sober-body/src/components/LineNavigator.tsx
@@ -1,0 +1,24 @@
+import React from 'react'
+
+export interface LineNavigatorProps {
+  lines: string[]
+  active: number
+  onSelect: (i: number) => void
+}
+
+export default function LineNavigator({ lines, active, onSelect }: LineNavigatorProps) {
+  return (
+    <ul className="space-y-1 text-sm overflow-y-auto">
+      {lines.map((line, i) => (
+        <li key={i}>
+          <button
+            className={'w-full text-left ' + (i === active ? 'font-bold' : '')}
+            onClick={() => onSelect(i)}
+          >
+            {line}
+          </button>
+        </li>
+      ))}
+    </ul>
+  )
+}

--- a/apps/sober-body/src/components/PronunciationCoachUI.tsx
+++ b/apps/sober-body/src/components/PronunciationCoachUI.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
-import PronunciationCoach from '../features/games/PronunciationCoach'
+import { usePronunciationCoach } from '../features/games/PronunciationCoach'
+import LineNavigator from './LineNavigator'
 
 export default function PronunciationCoachUI() {
   const [raw, setRaw] = useState('She sells seashells')
@@ -17,13 +18,14 @@ export default function PronunciationCoachUI() {
   }
 
   const current = deck[index] ?? raw
+  const coach = usePronunciationCoach({ phrase: current, locale })
 
   return (
-    <div className="p-4 space-y-4 flex">
-      <div className="w-1/4 pr-4 border-r">
+    <div className="p-4 flex gap-4 items-start">
+      <div className="flex flex-col w-1/2 pr-4 border-r">
         <h2 className="text-xl font-semibold mb-2">Pronunciation Coach</h2>
         <textarea
-          className="border p-2 w-full mb-2"
+          className="border p-2 w-full mb-2 resize-y min-h-[80vh]"
           value={raw}
           onChange={(e) => setRaw(e.target.value)}
         />
@@ -41,23 +43,19 @@ export default function PronunciationCoachUI() {
           </button>
         </div>
         {deck.length > 0 && (
-          <ul className="space-y-1 text-sm">
-            {deck.map((line, i) => (
-              <li key={i}>
-                <button
-                  className={
-                    'w-full text-left ' + (i === index ? 'font-bold' : '')
-                  }
-                  onClick={() => setIndex(i)}
-                >
-                  {line}
-                </button>
-              </li>
-            ))}
-          </ul>
+          <LineNavigator lines={deck} active={index} onSelect={setIndex} />
         )}
       </div>
       <div className="flex-1 pl-4 space-y-2">
+        <p>{current}</p>
+        <div className="space-x-2">
+          <button onClick={coach.play}>▶ Play</button>
+          <button
+            disabled={!(('SpeechRecognition' in window) || ('webkitSpeechRecognition' in window))}
+            onClick={coach.recording ? coach.stop : coach.start}
+          >{coach.recording ? '■ Stop' : '⏺ Record'}</button>
+          {coach.result !== null && <span>Score {coach.result}%</span>}
+        </div>
         {deck.length > 0 && (
           <div className="space-x-2">
             <button
@@ -76,7 +74,6 @@ export default function PronunciationCoachUI() {
             </button>
           </div>
         )}
-        <PronunciationCoach phrase={current} locale={locale} />
       </div>
     </div>
   )

--- a/apps/sober-body/src/features/games/PronunciationCoach.tsx
+++ b/apps/sober-body/src/features/games/PronunciationCoach.tsx
@@ -9,7 +9,7 @@ export interface PronunciationCoachProps {
   onScore?: (r: { score: number; transcript: string; millis: number }) => void
 }
 
-export default function PronunciationCoach({ phrase, locale, maxSecs, onScore }: PronunciationCoachProps) {
+export function usePronunciationCoach({ phrase, locale, maxSecs, onScore }: PronunciationCoachProps) {
   const [recording, setRecording] = useState(false)
   const [result, setResult] = useState<number | null>(null)
   const recRef = useRef<SpeechRecognition | null>(null)
@@ -57,14 +57,22 @@ export default function PronunciationCoach({ phrase, locale, maxSecs, onScore }:
     setTimeout(() => r.stop(), limit)
   }
 
+  const stop = () => recRef.current?.stop()
+
+  return { play, start, stop, recording, result }
+}
+
+export default function PronunciationCoach(props: PronunciationCoachProps) {
+  const coach = usePronunciationCoach(props)
+
   return (
     <div className="space-x-2">
-      <button onClick={play}>▶ Play</button>
+      <button onClick={coach.play}>▶ Play</button>
       <button
         disabled={!(('SpeechRecognition' in window) || ('webkitSpeechRecognition' in window))}
-        onClick={recording ? () => recRef.current?.stop() : start}
-      >{recording ? '■ Stop' : '⏺ Record'}</button>
-      {result !== null && <span>Score {result}%</span>}
+        onClick={coach.recording ? coach.stop : coach.start}
+      >{coach.recording ? '■ Stop' : '⏺ Record'}</button>
+      {coach.result !== null && <span>Score {coach.result}%</span>}
     </div>
   )
 }

--- a/docs/sprints/2025-06-sprint2-kickoff.md
+++ b/docs/sprints/2025-06-sprint2-kickoff.md
@@ -106,3 +106,10 @@ While the **Tongue‑Twister modal** lives inside *Sober‑Body*, the teacher‑
 | 6 | Post‑session report JSON download                             | placeholder until full teacher dashboard later                                                                |
 | 7 | Link from BAC header (🧑‍🏫 icon)                             | optional shortcut                                                                                             |
 | 8 | **Granularity selector** (line / sentence / paragraph / full) | student chooses drill scope; UI toggles chunk size before starting                                            |
+
+## 8 · UI refinement proposal
+
+* Add a flex container around the lesson builder and drill panes so the layout stretches with the viewport.
+* Textarea uses `min-height: 80vh` to give more room for multi-line lessons.
+* `<LineNavigator>` renders the parsed line list and calls `setIndex` when a line is clicked.
+* Play/Record controls sit in the right-hand drill pane next to the active phrase.


### PR DESCRIPTION
## Summary
- tweak PronunciationCoach to expose `usePronunciationCoach`
- add `LineNavigator` for selecting lines
- redesign `PronunciationCoachUI` with flex panes and relocated controls
- document the UI refinement proposal

## Testing
- `pnpm -r lint` *(fails: Cannot find package '@eslint/js')*
- `pnpm -r test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685dfeb9816c832b9a1acdb408e5ca03