### PR TITLE
Fix drink log initialization race

### DIFF
--- a/apps/sober-body/src/features/core/drink-context.tsx
+++ b/apps/sober-body/src/features/core/drink-context.tsx
@@ -17,8 +17,10 @@ export function DrinkLogProvider({ children }: { children: React.ReactNode }) {
 
   useEffect(() => {
     loadDrinks().then(arr => {
-      setDrinks(arr)
-      loaded.current = true
+      setDrinks(prev => {
+        loaded.current = true
+        return prev.length > 0 ? [...arr, ...prev] : arr
+      })
     })
   }, [])
 


### PR DESCRIPTION
## Summary
- ensure DrinkLogProvider merges stored drinks with any that are added before load completes

## Testing
- `pnpm -r test`


------
https://chatgpt.com/codex/tasks/task_e_685e19a82da0832baee6feb4bc0ebf49