### PR TITLE
feat(ui): add granularity splitting and responsive layout

### DIFF
--- a/apps/sober-body/src/components/PronunciationCoachUI.tsx
+++ b/apps/sober-body/src/components/PronunciationCoachUI.tsx
@@ -1,6 +1,32 @@
 import { useState } from 'react'
 import { usePronunciationCoach } from '../features/games/PronunciationCoach'
 
+type Scope = 'Word' | 'Line' | 'Sentence' | 'Paragraph' | 'Full'
+
+function splitText(raw: string, scope: Scope): string[] {
+  const trimmed = raw.trim()
+  switch (scope) {
+    case 'Word':
+      return trimmed.split(/\s+/).filter(Boolean)
+    case 'Line':
+      return trimmed.split(/\r?\n/).map((l) => l.trim()).filter(Boolean)
+    case 'Sentence':
+      return trimmed
+        .replace(/\r?\n/g, ' ')
+        .split(/(?<=[.!?])\s+/)
+        .map((s) => s.trim())
+        .filter(Boolean)
+    case 'Paragraph':
+      return trimmed
+        .split(/\r?\n\s*\r?\n/)
+        .map((p) => p.trim())
+        .filter(Boolean)
+    case 'Full':
+    default:
+      return trimmed ? [trimmed] : []
+  }
+}
+
 export default function PronunciationCoachUI() {
   const [raw, setRaw] = useState('She sells seashells')
   const [deck, setDeck] = useState<string[]>([])
@@ -9,10 +35,7 @@ export default function PronunciationCoachUI() {
   const [gran, setGran] = useState('Line')
 
   const start = () => {
-    const lines = raw
-      .split(/\r?\n/)
-      .map((l) => l.trim())
-      .filter(Boolean)
+    const lines = splitText(raw, gran as Scope)
     setDeck(lines)
     setIndex(0)
   }
@@ -21,8 +44,8 @@ export default function PronunciationCoachUI() {
   const coach = usePronunciationCoach({ phrase: current, locale })
 
   return (
-    <div className="flex flex-col md:flex-row gap-6 w-full p-4">
-      <section className="w-full md:w-5/12 flex flex-col">
+    <div className="flex flex-col sm:flex-row gap-6 w-full p-4">
+      <section className="w-full sm:w-5/12 flex flex-col">
         <textarea
           rows={14}
           className="w-full resize-y min-h-40 max-h-[80vh] overflow-y-auto border p-2"
@@ -54,7 +77,7 @@ export default function PronunciationCoachUI() {
           </button>
         </div>
         {deck.length > 0 && (
-          <ul className="list-disc pl-6 space-y-1 overflow-y-auto">
+          <ul className="list-disc pl-6 space-y-1 overflow-y-auto flex-1">
             {deck.map((line, i) => (
               <li
                 key={i}
@@ -67,7 +90,7 @@ export default function PronunciationCoachUI() {
           </ul>
         )}
       </section>
-      <section className="w-full md:w-7/12 flex flex-col items-center">
+      <section className="w-full sm:w-7/12 flex flex-col items-center">
         <h2 className="text-xl mb-2">{current}</h2>
         <div className="space-x-2 mb-2">
           <button onClick={coach.play}>▶ Play</button>


### PR DESCRIPTION
## Summary
- support splitting text by word, sentence or paragraph using `splitText`
- adjust layout to split into two columns at the `sm` breakpoint
- make parsed list scrollable

## Testing
- `pnpm -r lint`
- `pnpm -r test`


------
https://chatgpt.com/codex/tasks/task_e_685e1f292938832b95f3c3f89142b185