### PR TITLE
fix(ui): wrap parsed list in scrollable div

### DIFF
--- a/apps/sober-body/src/components/PronunciationCoachUI.tsx
+++ b/apps/sober-body/src/components/PronunciationCoachUI.tsx
@@ -77,17 +77,19 @@ export default function PronunciationCoachUI() {
           </button>
         </div>
         {deck.length > 0 && (
-          <ul className="list-disc pl-6 space-y-1 overflow-y-auto flex-1">
-            {deck.map((line, i) => (
-              <li
-                key={i}
-                onClick={() => setIndex(i)}
-                className={i === index ? 'font-bold cursor-pointer' : 'cursor-pointer'}
-              >
-                {line.slice(0, 80)}
-              </li>
-            ))}
-          </ul>
+          <div className="overflow-y-auto flex-1">
+            <ul className="list-disc pl-6 space-y-1">
+              {deck.map((line, i) => (
+                <li
+                  key={i}
+                  onClick={() => setIndex(i)}
+                  className={i === index ? 'font-bold cursor-pointer' : 'cursor-pointer'}
+                >
+                  {line.slice(0, 80)}
+                </li>
+              ))}
+            </ul>
+          </div>
         )}
       </section>
       <section className="w-full sm:w-7/12 flex flex-col items-center">


### PR DESCRIPTION
## Summary
- wrap pronunciation list in an overflow container so the parent flex column doesn't collapse

## Testing
- `pnpm -r lint`
- `pnpm -r test`


------
https://chatgpt.com/codex/tasks/task_e_685e21443b3c832bbf03e2d205c8059d