### PR TITLE
feat(ui): move parsed lines to drill section

### DIFF
--- a/apps/sober-body/src/components/PronunciationCoachUI.tsx
+++ b/apps/sober-body/src/components/PronunciationCoachUI.tsx
@@ -1,47 +1,50 @@
-import { useState } from 'react'
-import { usePronunciationCoach } from '../features/games/PronunciationCoach'
+import { useState } from "react";
+import { usePronunciationCoach } from "../features/games/PronunciationCoach";
 
-type Scope = 'Word' | 'Line' | 'Sentence' | 'Paragraph' | 'Full'
+type Scope = "Word" | "Line" | "Sentence" | "Paragraph" | "Full";
 
 function splitText(raw: string, scope: Scope): string[] {
-  const trimmed = raw.trim()
+  const trimmed = raw.trim();
   switch (scope) {
-    case 'Word':
-      return trimmed.split(/\s+/).filter(Boolean)
-    case 'Line':
-      return trimmed.split(/\r?\n/).map((l) => l.trim()).filter(Boolean)
-    case 'Sentence':
+    case "Word":
+      return trimmed.split(/\s+/).filter(Boolean);
+    case "Line":
       return trimmed
-        .replace(/\r?\n/g, ' ')
+        .split(/\r?\n/)
+        .map((l) => l.trim())
+        .filter(Boolean);
+    case "Sentence":
+      return trimmed
+        .replace(/\r?\n/g, " ")
         .split(/(?<=[.!?])\s+/)
         .map((s) => s.trim())
-        .filter(Boolean)
-    case 'Paragraph':
+        .filter(Boolean);
+    case "Paragraph":
       return trimmed
         .split(/\r?\n\s*\r?\n/)
         .map((p) => p.trim())
-        .filter(Boolean)
-    case 'Full':
+        .filter(Boolean);
+    case "Full":
     default:
-      return trimmed ? [trimmed] : []
+      return trimmed ? [trimmed] : [];
   }
 }
 
 export default function PronunciationCoachUI() {
-  const [raw, setRaw] = useState('She sells seashells')
-  const [deck, setDeck] = useState<string[]>([])
-  const [index, setIndex] = useState(0)
-  const [locale, setLocale] = useState<'en-US' | 'pt-BR'>('en-US')
-  const [gran, setGran] = useState('Line')
+  const [raw, setRaw] = useState("She sells seashells");
+  const [deck, setDeck] = useState<string[]>([]);
+  const [index, setIndex] = useState(0);
+  const [locale, setLocale] = useState<"en-US" | "pt-BR">("en-US");
+  const [gran, setGran] = useState("Line");
 
   const start = () => {
-    const lines = splitText(raw, gran as Scope)
-    setDeck(lines)
-    setIndex(0)
-  }
+    const lines = splitText(raw, gran as Scope);
+    setDeck(lines);
+    setIndex(0);
+  };
 
-  const current = deck[index] ?? raw
-  const coach = usePronunciationCoach({ phrase: current, locale })
+  const current = deck[index] ?? raw;
+  const coach = usePronunciationCoach({ phrase: current, locale });
 
   return (
     <div className="grid gap-6 w-full p-4 sm:grid-cols-2">
@@ -67,7 +70,7 @@ export default function PronunciationCoachUI() {
           <select
             className="border p-1"
             value={locale}
-            onChange={(e) => setLocale(e.target.value as 'en-US' | 'pt-BR')}
+            onChange={(e) => setLocale(e.target.value as "en-US" | "pt-BR")}
           >
             <option value="en-US">English</option>
             <option value="pt-BR">Portuguese</option>
@@ -76,30 +79,42 @@ export default function PronunciationCoachUI() {
             Start Drill
           </button>
         </div>
+      </section>
+      <section className="flex flex-col items-center space-y-4">
         {deck.length > 0 && (
-          <ul className="list-disc pl-6 space-y-1 overflow-y-auto flex-1">
-            {deck.map((line, i) =>
-              line && (
-                <li
-                  key={i}
-                  onClick={() => setIndex(i)}
-                  className={i === index ? 'font-bold cursor-pointer' : 'cursor-pointer'}
-                >
-                  {line}
-                </li>
-              )
+          <ul className="list-disc pl-6 space-y-1 overflow-y-auto w-full max-w-md">
+            {deck.map(
+              (line, i) =>
+                line && (
+                  <li
+                    key={i}
+                    onClick={() => setIndex(i)}
+                    className={
+                      i === index
+                        ? "font-bold cursor-pointer"
+                        : "cursor-pointer"
+                    }
+                  >
+                    {line}
+                  </li>
+                ),
             )}
           </ul>
         )}
-      </section>
-      <section className="flex flex-col items-center space-y-4">
         <h2 className="text-2xl text-center">{current}</h2>
         <div className="flex gap-2 items-center">
           <button onClick={coach.play}>▶ Play</button>
           <button
-            disabled={!(('SpeechRecognition' in window) || ('webkitSpeechRecognition' in window))}
+            disabled={
+              !(
+                "SpeechRecognition" in window ||
+                "webkitSpeechRecognition" in window
+              )
+            }
             onClick={coach.recording ? coach.stop : coach.start}
-          >{coach.recording ? '■ Stop' : '⏺ Record'}</button>
+          >
+            {coach.recording ? "■ Stop" : "⏺ Record"}
+          </button>
           {coach.result !== null && <span>Score {coach.result}%</span>}
         </div>
         {deck.length > 0 && (
@@ -122,5 +137,5 @@ export default function PronunciationCoachUI() {
         )}
       </section>
     </div>
-  )
+  );
 }


### PR DESCRIPTION
## Summary
- keep lesson builder clean by relocating the parsed list to the practice section

## Testing
- `pnpm -r lint`
- `pnpm -r test`


------
https://chatgpt.com/codex/tasks/task_e_685e2b361184832b989a0f5a45897e02