### PR TITLE
Add double-click translation tooltip to Pronunciation Coach

### DIFF
--- a/apps/sober-body/src/components/PronunciationCoachUI.tsx
+++ b/apps/sober-body/src/components/PronunciationCoachUI.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from "react";
 import { usePronunciationCoach } from "../features/games/PronunciationCoach";
+import Tooltip from "../../../../packages/pronunciation-coach/src/Tooltip";
 
 type Scope = "Word" | "Line" | "Sentence" | "Paragraph" | "Full";
 
@@ -36,6 +37,8 @@ export default function PronunciationCoachUI() {
   const [deck, setDeck] = useState<string[]>([]);
   const [index, setIndex] = useState(0);
   const [locale, setLocale] = useState<"en-US" | "pt-BR">("en-US");
+  const [lookupWord, setLookupWord] = useState<string | null>(null);
+  const [tipPos, setTipPos] = useState<{ x: number; y: number }>({ x: 0, y: 0 });
 
   useEffect(() => {
     setDeck(splitText(raw, scope));
@@ -102,7 +105,21 @@ export default function PronunciationCoachUI() {
           </ul>
         )}
         <div className="flex flex-col items-center space-y-3 self-center">
-          <h2 className="text-2xl font-semibold text-center">{current}</h2>
+          <h2 className="text-2xl font-semibold text-center">
+            {current.split(/\s+/).map((w, i) => (
+              <span
+                key={i}
+                onDoubleClick={e => {
+                  const rect = (e.target as HTMLElement).getBoundingClientRect()
+                  setTipPos({ x: rect.left, y: rect.bottom })
+                  setLookupWord(w)
+                }}
+                className="cursor-help mx-0.5"
+              >
+                {w + ' '}
+              </span>
+            ))}
+          </h2>
           <div className="flex gap-2 items-center">
             <button onClick={coach.play}>▶ Play</button>
             <button
@@ -139,6 +156,15 @@ export default function PronunciationCoachUI() {
         </div>
       </section>
       </div>
+      {lookupWord && (
+        <Tooltip
+          word={lookupWord}
+          lang={locale.split('-')[0]}
+          x={tipPos.x}
+          y={tipPos.y}
+          onClose={() => setLookupWord(null)}
+        />
+      )}
     </div>
   );
 }

--- a/packages/pronunciation-coach/package.json
+++ b/packages/pronunciation-coach/package.json
@@ -6,17 +6,21 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run"
   },
   "dependencies": {
     "react": "^19.1.0",
-    "react-dom": "^19.1.0"
+    "react-dom": "^19.1.0",
+    "idb-keyval": "^6.2.2"
   },
   "devDependencies": {
     "@types/react": "^19.1.2",
     "@types/react-dom": "^19.1.2",
     "@vitejs/plugin-react": "^4.4.1",
     "typescript": "~5.8.3",
-    "vite": "^6.3.5"
+    "vite": "^6.3.5",
+    "vitest": "^1.6.1",
+    "fake-indexeddb": "^5.0.2"
   }
 }

--- a/packages/pronunciation-coach/src/Tooltip.tsx
+++ b/packages/pronunciation-coach/src/Tooltip.tsx
@@ -1,0 +1,40 @@
+import React, { useEffect } from 'react'
+import useTranslation from './useTranslation'
+
+interface Props {
+  word: string
+  lang: string
+  x: number
+  y: number
+  onClose: () => void
+}
+
+export default function Tooltip({ word, lang, x, y, onClose }: Props) {
+  const translation = useTranslation(word, lang)
+
+  useEffect(() => {
+    const handler = (e: MouseEvent) => {
+      if (!(e.target as HTMLElement).closest('.pc-tooltip')) onClose()
+    }
+    document.addEventListener('click', handler)
+    return () => document.removeEventListener('click', handler)
+  }, [onClose])
+
+  const speak = () => {
+    const u = new SpeechSynthesisUtterance(word)
+    u.lang = lang
+    speechSynthesis.speak(u)
+  }
+
+  return (
+    <div
+      className="pc-tooltip absolute bg-white border rounded shadow-md p-2 text-sm"
+      style={{ top: y, left: x }}
+    >
+      <div className="flex items-center gap-2">
+        <span>{translation ?? '…'}</span>
+        <button onClick={speak} aria-label="play word">🔊</button>
+      </div>
+    </div>
+  )
+}

--- a/packages/pronunciation-coach/src/storage.ts
+++ b/packages/pronunciation-coach/src/storage.ts
@@ -1,0 +1,15 @@
+import { get, set } from 'idb-keyval'
+
+const PREFIX = 'pc_vocab_'
+
+export async function getCachedTranslation(lang: string, word: string): Promise<string | undefined> {
+  const store = await get<Record<string, string>>(PREFIX + lang)
+  return store?.[word.toLowerCase()]
+}
+
+export async function cacheTranslation(lang: string, word: string, text: string): Promise<void> {
+  const key = PREFIX + lang
+  const obj = (await get<Record<string, string>>(key)) ?? {}
+  obj[word.toLowerCase()] = text
+  await set(key, obj)
+}

--- a/packages/pronunciation-coach/src/translate.test.ts
+++ b/packages/pronunciation-coach/src/translate.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import 'fake-indexeddb/auto'
+import { translate } from './translate'
+
+async function clearDB() {
+  const dbs = await indexedDB.databases?.()
+  if (dbs) await Promise.all(dbs.map(db => indexedDB.deleteDatabase(db.name!)))
+}
+
+describe('translate util', () => {
+  beforeEach(async () => {
+    await clearDB()
+    vi.stubGlobal('fetch', vi.fn(async () => ({
+      json: async () => [{ translations: [{ text: 'hola' }] }]
+    })) as unknown as typeof fetch)
+  })
+
+  it('hits cache on second call', async () => {
+    const first = await translate('hello', 'es')
+    expect(first).toBe('hola')
+    expect(fetch).toHaveBeenCalledTimes(1)
+    const second = await translate('hello', 'es')
+    expect(second).toBe('hola')
+    expect(fetch).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/pronunciation-coach/src/translate.ts
+++ b/packages/pronunciation-coach/src/translate.ts
@@ -1,0 +1,26 @@
+import { cacheTranslation, getCachedTranslation } from './storage'
+
+export async function translateAPI(word: string, lang: string): Promise<string> {
+  const key = (import.meta as any).env.VITE_TRANSLATOR_KEY
+  const region = (import.meta as any).env.VITE_TRANSLATOR_REGION
+  const url = `https://api.cognitive.microsofttranslator.com/translate?api-version=3.0&to=${lang}`
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'Ocp-Apim-Subscription-Key': key,
+      'Ocp-Apim-Subscription-Region': region,
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify([{ text: word }])
+  })
+  const data = await res.json()
+  return data[0].translations[0].text as string
+}
+
+export async function translate(word: string, lang: string): Promise<string> {
+  const cached = await getCachedTranslation(lang, word)
+  if (cached) return cached
+  const text = await translateAPI(word, lang)
+  await cacheTranslation(lang, word, text)
+  return text
+}

--- a/packages/pronunciation-coach/src/useTranslation.ts
+++ b/packages/pronunciation-coach/src/useTranslation.ts
@@ -1,0 +1,17 @@
+import { useEffect, useState } from 'react'
+import { translate } from './translate'
+
+export default function useTranslation(word: string, lang: string) {
+  const [result, setResult] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!word) { setResult(null); return }
+    let active = true
+    translate(word, lang).then(t => {
+      if (active) setResult(t)
+    })
+    return () => { active = false }
+  }, [word, lang])
+
+  return result
+}

--- a/packages/pronunciation-coach/vite.config.ts
+++ b/packages/pronunciation-coach/vite.config.ts
@@ -5,5 +5,8 @@ export default defineConfig({
   plugins: [react()],
   server: {
     port: 5174
+  },
+  test: {
+    environment: 'jsdom'
   }
 })


### PR DESCRIPTION
## Summary
- store translations in IndexedDB for Pronunciation Coach
- fetch Azure Cognitive Translator results and cache them
- expose `useTranslation` hook and `Tooltip` UI
- show per-word tooltips in PronunciationCoachUI
- test cache behaviour in `translate` util

## Testing
- `pnpm -r lint`
- `pnpm -r test`


------
https://chatgpt.com/codex/tasks/task_e_685f3aeac4c0832ba8be2f01ff206098