### PR TITLE
Rename workspace sober-body-pwa → sober-body

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,8 @@ The project now uses a **pnpm workspace** with two packages under `apps/` and `p
 The main PWA lives in [`apps/sober-body/`](apps/sober-body/):
 
 ```bash
-cd apps/sober-body
 pnpm install
-pnpm run dev
+pnpm --filter sober-body dev
 # open http://localhost:5173/app
 ```
 
@@ -21,6 +20,14 @@ cd packages/pronunciation-coach
 pnpm install
 pnpm run dev
 # open http://localhost:5174
+```
+
+## Testing
+
+Run the unit tests for the PWA workspace:
+
+```bash
+pnpm --filter sober-body test
 ```
 
 ## Repository layout

--- a/apps/sober-body/package.json
+++ b/apps/sober-body/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "sober-body-pwa",
+  "name": "sober-body",
   "private": true,
   "version": "0.0.0",
   "type": "module",

--- a/docs/sprints/2025-06-sprint2-kickoff.md
+++ b/docs/sprints/2025-06-sprint2-kickoff.md
@@ -89,7 +89,7 @@ While the **Tongue‑Twister modal** lives inside *Sober‑Body*, the teacher‑
 
 | Mode                        | How to launch                                    | URL                                                                     |
 | --------------------------- | ------------------------------------------------ | ----------------------------------------------------------------------- |
-| **Local dev** (single Vite) | `pnpm --filter apps/sober-body dev`              | [http://localhost:5173/coach](http://localhost:5173/coach)              |
+| **Local dev** (single Vite) | `pnpm --filter sober-body dev`              | [http://localhost:5173/coach](http://localhost:5173/coach)              |
 | **Package playground**      | `pnpm --filter packages/pronunciation-coach dev` | [http://localhost:5174/](http://localhost:5174/) (Storybook / mini‑app) |
 
 *(Both will exist; teachers can use either, while the BAC Dashboard can link to **`/coach`**.)*

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "workspaces": ["apps/*", "packages/*"],
   "scripts": {
-    "dev:sober": "pnpm --filter apps/sober-body dev",
+    "dev:sober": "pnpm --filter sober-body dev",
     "dev:coach": "pnpm --filter packages/pronunciation-coach dev",
     "dev:all": "pnpm -r dev",
     "test": "pnpm -r --parallel test"


### PR DESCRIPTION
## Summary
- rename the PWA workspace to `sober-body`
- use workspace filter in root scripts
- update docs and quickstart commands

## Testing
- `pnpm -r test`


------
https://chatgpt.com/codex/tasks/task_e_686026f9dc98832b8c573f120a5e246b