### PR TITLE
Fix translator env handling

### DIFF
--- a/packages/pronunciation-coach/README.md
+++ b/packages/pronunciation-coach/README.md
@@ -5,3 +5,11 @@ Standalone React playground for the PronunciationCoach component used in Soberâ€
 ```
 pnpm --filter packages/pronunciation-coach dev
 ```
+
+Create a `.env.local` file in this directory with the following keys to enable
+translation features:
+
+```
+VITE_TRANSLATOR_KEY=your-azure-key
+VITE_TRANSLATOR_REGION=your-region
+```

--- a/packages/pronunciation-coach/src/translate.test.ts
+++ b/packages/pronunciation-coach/src/translate.test.ts
@@ -10,6 +10,8 @@ async function clearDB() {
 describe('translate util', () => {
   beforeEach(async () => {
     await clearDB()
+    vi.stubEnv('VITE_TRANSLATOR_KEY', 'x')
+    vi.stubEnv('VITE_TRANSLATOR_REGION', 'y')
     vi.stubGlobal('fetch', vi.fn(async () => ({
       json: async () => [{ translations: [{ text: 'hola' }] }]
     })) as unknown as typeof fetch)

--- a/packages/pronunciation-coach/src/translate.ts
+++ b/packages/pronunciation-coach/src/translate.ts
@@ -1,8 +1,12 @@
 import { cacheTranslation, getCachedTranslation } from './storage'
 
 export async function translateAPI(word: string, lang: string): Promise<string> {
-  const key = (import.meta as any).env.VITE_TRANSLATOR_KEY
-  const region = (import.meta as any).env.VITE_TRANSLATOR_REGION
+  const env = import.meta as any
+  const key = env.env.VITE_TRANSLATOR_KEY
+  const region = env.env.VITE_TRANSLATOR_REGION
+  if (!key || !region) {
+    throw new Error('Missing VITE_TRANSLATOR_KEY or VITE_TRANSLATOR_REGION')
+  }
   const url = `https://api.cognitive.microsofttranslator.com/translate?api-version=3.0&to=${lang}`
   const res = await fetch(url, {
     method: 'POST',


### PR DESCRIPTION
## Summary
- guard against missing translator environment variables
- document expected `.env.local` variables for translator
- stub translator env vars in tests

## Testing
- `pnpm -r lint`
- `pnpm -r test`


------
https://chatgpt.com/codex/tasks/task_e_68602ff8d54c832b954dba7f48c06ed8