### PR TITLE
fix(core): use import.meta.env for translator key

### DIFF
--- a/packages/pronunciation-coach/src/translate.ts
+++ b/packages/pronunciation-coach/src/translate.ts
@@ -1,9 +1,8 @@
 import { cacheTranslation, getCachedTranslation } from './storage'
 
 export async function translateAPI(word: string, lang: string): Promise<string> {
-  const env = import.meta as any
-  const key = env.env.VITE_TRANSLATOR_KEY
-  const region = env.env.VITE_TRANSLATOR_REGION
+  const key = import.meta.env.VITE_TRANSLATOR_KEY
+  const region = import.meta.env.VITE_TRANSLATOR_REGION
   if (!key || !region) {
     throw new Error('Missing VITE_TRANSLATOR_KEY or VITE_TRANSLATOR_REGION')
   }


### PR DESCRIPTION
## Summary
- fix translator env variable detection

## Testing
- `pnpm -r lint`
- `pnpm -r test`


------
https://chatgpt.com/codex/tasks/task_e_68603dce38c0832b882f54baade0d8f0