### PR TITLE
feat/ui: add spacing in pronunciation coach

### DIFF
--- a/apps/sober-body/src/components/PronunciationCoachUI.tsx
+++ b/apps/sober-body/src/components/PronunciationCoachUI.tsx
@@ -130,7 +130,7 @@ export default function PronunciationCoachUI() {
             )}
           </ul>
         )}
-        <div className="flex flex-col items-center space-y-3 self-center">
+        <div className="flex flex-col items-center space-y-4 self-center">
           <h2 className="text-2xl font-semibold text-center">
             {current.split(/\s+/).map((w, i) => (
               <span


### PR DESCRIPTION
## Summary
- add extra space between play controls, translation and next buttons

## Testing
- `pnpm -r lint`
- `pnpm -r test`


------
https://chatgpt.com/codex/tasks/task_e_68607015c74c832b99466f42f29acd24