### PR TITLE
UX polish — spacing, selection translation, unified language list

### DIFF
--- a/apps/sober-body/src/components/PronunciationCoachUI.test.tsx
+++ b/apps/sober-body/src/components/PronunciationCoachUI.test.tsx
@@ -1,0 +1,30 @@
+import { render, fireEvent, screen } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import 'fake-indexeddb/auto'
+import PronunciationCoachUI from './PronunciationCoachUI'
+import { SettingsProvider } from '../features/core/settings-context'
+import { installSpeechMocks } from '../../test/utils/mockSpeech'
+
+vi.mock('../../../../packages/pronunciation-coach/src/useTranslation', () => ({
+  default: vi.fn(() => 'bonjour')
+}))
+
+beforeEach(() => {
+  installSpeechMocks()
+})
+
+describe('PronunciationCoachUI translation', () => {
+  it('translates selected sentence to French', async () => {
+    const getSelection = vi.fn(() => ({ toString: () => 'She sells seashells' }))
+    Object.defineProperty(window, 'getSelection', { value: getSelection })
+    render(
+      <SettingsProvider>
+        <PronunciationCoachUI />
+      </SettingsProvider>
+    )
+    fireEvent.change(screen.getByLabelText(/Translate to/i), { target: { value: 'fr' } })
+    fireEvent.doubleClick(screen.getByRole('heading'))
+    expect(await screen.findByText('bonjour')).toBeTruthy()
+  })
+})
+

--- a/apps/sober-body/src/features/core/settings-context.test.tsx
+++ b/apps/sober-body/src/features/core/settings-context.test.tsx
@@ -33,7 +33,7 @@ describe('SettingsProvider persistence', () => {
     await waitFor(() => expect(storage.loadSettings).toHaveBeenCalled())
     fireEvent.click(screen.getByRole('button', { name: /change/i }))
     await waitFor(() => {
-      expect(storage.saveSettings).toHaveBeenCalledWith({ weightKg: 80, sex: 'm', beta: DEFAULT_BETA, nativeLang: 'en' })
+      expect(storage.saveSettings).toHaveBeenCalledWith({ weightKg: 80, sex: 'm', beta: DEFAULT_BETA, nativeLang: 'en', locale: 'en' })
     })
     first.unmount()
     render(

--- a/apps/sober-body/src/features/core/settings-context.tsx
+++ b/apps/sober-body/src/features/core/settings-context.tsx
@@ -10,7 +10,8 @@ const DEFAULTS: Required<Settings> = {
   weightKg: 70,
   sex: 'm',
   beta: DEFAULT_BETA,
-  nativeLang: 'en'
+  nativeLang: 'en',
+  locale: 'en'
 }
 const SettingsContext = createContext<SettingsValue | undefined>(undefined)
 export function SettingsProvider({ children }: { children: React.ReactNode }) {

--- a/apps/sober-body/src/features/core/storage.ts
+++ b/apps/sober-body/src/features/core/storage.ts
@@ -16,6 +16,7 @@ export interface Settings {
   sex?: 'm' | 'f'
   beta?: number
   nativeLang?: string
+  locale?: string
 }
 
 export async function loadSettings(): Promise<Settings | undefined> {

--- a/apps/sober-body/test/utils/mockSpeech.ts
+++ b/apps/sober-body/test/utils/mockSpeech.ts
@@ -6,6 +6,10 @@ export function installSpeechMocks() {
     cancel: vi.fn(),
     getVoices: () => [{ name: 'MockVoice', lang: 'en-US' }],
   } as unknown as SpeechSynthesis
+  ;(globalThis as Record<string, unknown>).SpeechSynthesisUtterance = function(this: SpeechSynthesisUtterance, text: string) {
+    this.text = text
+    this.lang = 'en-US'
+  } as unknown as typeof SpeechSynthesisUtterance
 
   class MockRecognition extends EventTarget {
     lang = 'en-US'

--- a/packages/pronunciation-coach/src/langs.ts
+++ b/packages/pronunciation-coach/src/langs.ts
@@ -1,0 +1,10 @@
+export const LANGS = [
+  { code: 'en', label: 'English' },
+  { code: 'es', label: 'Spanish' },
+  { code: 'fr', label: 'French' },
+  { code: 'de', label: 'German' },
+  { code: 'pt-BR', label: 'Portuguese' },
+  { code: 'ru', label: 'Russian' },
+  { code: 'zh-Hans', label: 'Chinese (Simplified)' }
+] as const;
+export type LangCode = typeof LANGS[number]['code'];


### PR DESCRIPTION
## Summary
- update layout in PronunciationCoach drill for better spacing
- allow selecting sentences for translation
- auto-play translation and toggle via `T`
- add language list constant and use across selects
- extend settings with `locale`
- add unit test for selection translation

## Testing
- `pnpm --filter sober-body lint`
- `pnpm --filter sober-body test`

------
https://chatgpt.com/codex/tasks/task_e_68607ca823b8832ba8828a49e74df9aa