### PR TITLE
feat: allow phrase selection for translation

### DIFF
--- a/apps/sober-body/src/components/PronunciationCoachUI.test.tsx
+++ b/apps/sober-body/src/components/PronunciationCoachUI.test.tsx
@@ -23,7 +23,7 @@ describe('PronunciationCoachUI translation', () => {
       </SettingsProvider>
     )
     fireEvent.change(screen.getByLabelText(/Translate to/i), { target: { value: 'fr' } })
-    fireEvent.doubleClick(screen.getByRole('heading'))
+    fireEvent.mouseUp(screen.getByRole('heading'))
     expect(await screen.findByText('bonjour')).toBeTruthy()
   })
 })

--- a/apps/sober-body/src/components/PronunciationCoachUI.tsx
+++ b/apps/sober-body/src/components/PronunciationCoachUI.tsx
@@ -2,7 +2,6 @@ import { useState, useEffect } from "react";
 import { usePronunciationCoach } from "../features/games/PronunciationCoach";
 import useTranslation from "../../../../packages/pronunciation-coach/src/useTranslation";
 import { LANGS } from "../../../../packages/pronunciation-coach/src/langs";
-import { getLookup } from "../../../../packages/pronunciation-coach/src/translateLookup";
 import { useSettings } from "../features/core/settings-context";
 
 type Scope = "Word" | "Line" | "Sentence" | "Paragraph" | "Full";
@@ -77,7 +76,7 @@ export default function PronunciationCoachUI() {
 
   return (
     <div className="min-h-screen flex justify-center pt-8">
-      <div className="grid grid-cols-2 gap-12 w-full max-w-5xl p-4">
+      <div className="grid grid-cols-2 gap-20 w-full max-w-6xl p-8">
       <section className="flex flex-col space-y-2">
         <textarea
           rows={14}
@@ -124,7 +123,7 @@ export default function PronunciationCoachUI() {
       </section>
       <section className="flex flex-col items-center">
         {deck.length > 0 && (
-          <ul className="list-disc pl-8 pr-4 space-y-1 overflow-y-auto w-full max-w-md">
+          <ul className="list-disc pl-10 pr-6 space-y-1 overflow-y-auto w-full max-w-md">
             {deck.map(
               (line, i) =>
                 line && (
@@ -143,22 +142,18 @@ export default function PronunciationCoachUI() {
             )}
           </ul>
         )}
-        <div className="flex flex-col items-center">
-          <h2
-            className="text-2xl text-center mb-6"
-            onDoubleClick={e => setLookupWord(getLookup(e.nativeEvent))}
-          >
-            {current.split(/\s+/).map((w, i) => (
-              <span
-                key={i}
-                onDoubleClick={e => setLookupWord(getLookup(e.nativeEvent))}
-                className="cursor-help mx-0.5"
-              >
-                {w + ' '}
-              </span>
-            ))}
-          </h2>
-          <div className="flex gap-4 mb-6">
+        <h2
+          className="text-2xl text-center mb-8 select-text"
+          onMouseUp={() => {
+            const raw = window.getSelection()?.toString().trim();
+            if (!raw) return;
+            const cleaned = raw.replace(/[^\p{L}\p{N}\s]+/gu, '');
+            setLookupWord(cleaned);
+          }}
+        >
+          {current}
+        </h2>
+        <div className="flex gap-4 mb-8">
             <button onClick={coach.play}>▶ Play</button>
             <button
               disabled={
@@ -173,13 +168,13 @@ export default function PronunciationCoachUI() {
             </button>
             {coach.result !== null && <span>Score {coach.result}%</span>}
           </div>
-          {translation && showTranslation && (
-            <div className="flex items-center gap-2 mb-6 rounded-md border px-4 py-2 bg-white/90 shadow max-w-xs text-sm">
+        {translation && showTranslation && (
+            <div className="flex items-center gap-2 mb-8 rounded-md border px-4 py-2 bg-white/90 shadow max-w-xs text-sm">
               <span>{translation}</span>
               <button onClick={speak}>🔊</button>
             </div>
           )}
-          {deck.length > 0 && (
+        {deck.length > 0 && (
             <div className="flex gap-4">
               <button
                 onClick={() => setIndex((i) => i - 1)}
@@ -197,7 +192,6 @@ export default function PronunciationCoachUI() {
               </button>
             </div>
           )}
-        </div>
       </section>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- enable translating arbitrary selections via mouseup
- widen coach layout spacing
- update test for mouseup handler

## Testing
- `pnpm -r lint`
- `pnpm -r test`


------
https://chatgpt.com/codex/tasks/task_e_68608e270b54832b90800ce2b4a3e7fd