### PR TITLE
feat(coach): add slow speech toggle

### DIFF
--- a/apps/sober-body/src/components/PronunciationCoachUI.test.tsx
+++ b/apps/sober-body/src/components/PronunciationCoachUI.test.tsx
@@ -22,9 +22,31 @@ describe('PronunciationCoachUI translation', () => {
         <PronunciationCoachUI />
       </SettingsProvider>
     )
-    fireEvent.change(screen.getByLabelText(/Translate to/i), { target: { value: 'fr' } })
-    fireEvent.mouseUp(screen.getByRole('heading'))
+    const langSelect = screen.getAllByLabelText(/Translate to/i)[0]
+    fireEvent.change(langSelect, { target: { value: 'fr' } })
+    const heading = screen.getAllByRole('heading')[0]
+    fireEvent.mouseUp(heading)
     expect(await screen.findByText('bonjour')).toBeTruthy()
+  })
+
+  it('speaks slower when slow mode enabled', async () => {
+    const getSelection = vi.fn(() => ({ toString: () => 'She sells seashells' }))
+    Object.defineProperty(window, 'getSelection', { value: getSelection })
+    render(
+      <SettingsProvider>
+        <PronunciationCoachUI />
+      </SettingsProvider>
+    )
+    const langSelect = screen.getAllByLabelText(/Translate to/i)[0]
+    fireEvent.change(langSelect, { target: { value: 'fr' } })
+    fireEvent.mouseUp(screen.getAllByRole('heading')[0])
+    await screen.findAllByText('bonjour')
+    fireEvent.click(screen.getAllByLabelText(/Slow speak/i)[0])
+    await Promise.resolve()
+    fireEvent.click(screen.getAllByRole('button', { name: '🔊' })[0])
+    const speakMock = speechSynthesis.speak as unknown as vi.Mock
+    const utter = speakMock.mock.calls[speakMock.mock.calls.length - 1][0] as SpeechSynthesisUtterance
+    expect(utter.rate).toBe(0.7)
   })
 })
 

--- a/apps/sober-body/src/components/PronunciationCoachUI.tsx
+++ b/apps/sober-body/src/components/PronunciationCoachUI.tsx
@@ -57,8 +57,11 @@ export default function PronunciationCoachUI() {
     const voice = speechSynthesis
       .getVoices()
       .find(v => v.lang.startsWith(settings.nativeLang)) ?? null;
-    if (voice) utter.voice = voice;
+    utter.voice = voice || null;
     utter.lang = settings.nativeLang;
+    utter.rate = settings.slowSpeech ? 0.7 : 0.9;
+    utter.pitch = 1.0;
+    speechSynthesis.cancel();
     speechSynthesis.speak(utter);
   };
 
@@ -75,8 +78,9 @@ export default function PronunciationCoachUI() {
   }, []);
 
   return (
-    <div className="min-h-screen flex justify-center pt-8">
-      <div className="grid grid-cols-2 gap-20 w-full max-w-6xl p-8">
+    <div
+      className="mx-auto max-w-7xl grid grid-cols-2 gap-x-24 gap-y-12 px-8 pt-10"
+    >
       <section className="flex flex-col space-y-2">
         <textarea
           rows={14}
@@ -168,6 +172,14 @@ export default function PronunciationCoachUI() {
             </button>
             {coach.result !== null && <span>Score {coach.result}%</span>}
           </div>
+        <label className="text-xs mt-2 flex items-center gap-1">
+          <input
+            type="checkbox"
+            checked={settings.slowSpeech}
+            onChange={e => setSettings(s => ({ ...s, slowSpeech: e.target.checked }))}
+          />
+          Slow speak
+        </label>
         {translation && showTranslation && (
             <div className="flex items-center gap-2 mb-8 rounded-md border px-4 py-2 bg-white/90 shadow max-w-xs text-sm">
               <span>{translation}</span>
@@ -193,7 +205,6 @@ export default function PronunciationCoachUI() {
             </div>
           )}
       </section>
-      </div>
     </div>
   );
 }

--- a/apps/sober-body/src/features/core/settings-context.test.tsx
+++ b/apps/sober-body/src/features/core/settings-context.test.tsx
@@ -33,7 +33,7 @@ describe('SettingsProvider persistence', () => {
     await waitFor(() => expect(storage.loadSettings).toHaveBeenCalled())
     fireEvent.click(screen.getByRole('button', { name: /change/i }))
     await waitFor(() => {
-      expect(storage.saveSettings).toHaveBeenCalledWith({ weightKg: 80, sex: 'm', beta: DEFAULT_BETA, nativeLang: 'en', locale: 'en' })
+      expect(storage.saveSettings).toHaveBeenCalledWith({ weightKg: 80, sex: 'm', beta: DEFAULT_BETA, nativeLang: 'en', locale: 'en', slowSpeech: false })
     })
     first.unmount()
     render(

--- a/apps/sober-body/src/features/core/settings-context.tsx
+++ b/apps/sober-body/src/features/core/settings-context.tsx
@@ -11,7 +11,8 @@ const DEFAULTS: Required<Settings> = {
   sex: 'm',
   beta: DEFAULT_BETA,
   nativeLang: 'en',
-  locale: 'en'
+  locale: 'en',
+  slowSpeech: false
 }
 const SettingsContext = createContext<SettingsValue | undefined>(undefined)
 export function SettingsProvider({ children }: { children: React.ReactNode }) {

--- a/apps/sober-body/src/features/core/storage.ts
+++ b/apps/sober-body/src/features/core/storage.ts
@@ -17,6 +17,7 @@ export interface Settings {
   beta?: number
   nativeLang?: string
   locale?: string
+  slowSpeech?: boolean
 }
 
 export async function loadSettings(): Promise<Settings | undefined> {


### PR DESCRIPTION
## Summary
- space out Pronunciation Coach grid at large widths
- slow speech playback via settings
- checkbox toggle in Coach UI
- persist slowSpeech in settings storage
- test slow speech option

## Testing
- `pnpm -r lint`
- `pnpm -r test`


------
https://chatgpt.com/codex/tasks/task_e_686092f91c50832b8e7ced9762e8007f