### PR TITLE
feat: seed preset situation decks

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ pnpm run dev
 # open http://localhost:5174
 ```
 
+You can practice quickly via 🎒 Situations.
+
 Create a `.env.local` file at the repository root with your translation API
 credentials. All workspaces load environment variables from that shared file:
 

--- a/apps/sober-body/public/presets/groceries-de-DE.json
+++ b/apps/sober-body/public/presets/groceries-de-DE.json
@@ -1,0 +1,1 @@
+{"id":"preset-groceries-de-DE","title":"Im Supermarkt (DE-DE)","lang":"de-DE","preset":true,"lines":["Wo finde ich die Milchprodukteabteilung?","Wie viel kostet es pro Kilo?","Nehmen Sie Kreditkarten?","Können Sie diese Äpfel bitte wiegen?","Haben Sie wiederverwendbare Taschen?"]}

--- a/apps/sober-body/public/presets/groceries-en-US.json
+++ b/apps/sober-body/public/presets/groceries-en-US.json
@@ -1,0 +1,1 @@
+{"id":"preset-groceries-en-US","title":"At the Market (EN-US)","lang":"en-US","preset":true,"lines":["Where is the dairy section?","How much does it cost per kilo?","Do you take credit cards?","Could you weigh these apples, please?","Do you have reusable bags?"]}

--- a/apps/sober-body/public/presets/groceries-es-ES.json
+++ b/apps/sober-body/public/presets/groceries-es-ES.json
@@ -1,0 +1,1 @@
+{"id":"preset-groceries-es-ES","title":"En el Mercado (ES-ES)","lang":"es-ES","preset":true,"lines":["¿Dónde está la sección de lácteos?","¿Cuánto cuesta por kilo?","¿Aceptan tarjeta de crédito?","¿Podría pesar estas manzanas, por favor?","¿Tienen bolsas reutilizables?"]}

--- a/apps/sober-body/public/presets/groceries-fr-FR.json
+++ b/apps/sober-body/public/presets/groceries-fr-FR.json
@@ -1,0 +1,1 @@
+{"id":"preset-groceries-fr-FR","title":"Au Marché (FR-FR)","lang":"fr-FR","preset":true,"lines":["Où est le rayon des produits laitiers ?","Combien ça coûte au kilo ?","Acceptez-vous la carte de crédit ?","Pouvez-vous peser ces pommes, s’il vous plaît ?","Avez-vous des sacs réutilisables ?"]}

--- a/apps/sober-body/public/presets/groceries-pt-BR.json
+++ b/apps/sober-body/public/presets/groceries-pt-BR.json
@@ -1,0 +1,1 @@
+{"id":"preset-groceries-pt-BR","title":"No Mercado (PT-BR)","lang":"pt-BR","preset":true,"lines":["Onde fica a seção de laticínios?","Quanto custa por quilo?","Aceita cartão de crédito?","Pode pesar estas maçãs, por favor?","Tem sacolas reutilizáveis?"]}

--- a/apps/sober-body/public/presets/hotel-de-DE.json
+++ b/apps/sober-body/public/presets/hotel-de-DE.json
@@ -1,0 +1,1 @@
+{"id":"preset-hotel-de-DE","title":"Hotelrezeption (DE-DE)","lang":"de-DE","preset":true,"lines":["Ich habe eine Reservierung auf den Namen...","Ist das Frühstück inbegriffen?","Wann ist Check-out?","Könnte ich das WLAN-Passwort bekommen?","Haben Sie Zimmerservice?"]}

--- a/apps/sober-body/public/presets/hotel-en-US.json
+++ b/apps/sober-body/public/presets/hotel-en-US.json
@@ -1,0 +1,1 @@
+{"id":"preset-hotel-en-US","title":"Hotel Front Desk (EN-US)","lang":"en-US","preset":true,"lines":["I have a reservation under...","Is breakfast included?","What time is check-out?","Could I get the Wi-Fi password?","Do you have room service?"]}

--- a/apps/sober-body/public/presets/hotel-es-ES.json
+++ b/apps/sober-body/public/presets/hotel-es-ES.json
@@ -1,0 +1,1 @@
+{"id":"preset-hotel-es-ES","title":"Recepción de Hotel (ES-ES)","lang":"es-ES","preset":true,"lines":["Tengo una reserva a nombre de...","¿El desayuno está incluido?","¿A qué hora es el check-out?","¿Me puede dar la contraseña del Wi-Fi?","¿Tienen servicio de habitaciones?"]}

--- a/apps/sober-body/public/presets/hotel-fr-FR.json
+++ b/apps/sober-body/public/presets/hotel-fr-FR.json
@@ -1,0 +1,1 @@
+{"id":"preset-hotel-fr-FR","title":"Réception d'Hôtel (FR-FR)","lang":"fr-FR","preset":true,"lines":["J’ai une réservation au nom de...","Le petit-déjeuner est-il inclus ?","À quelle heure est le check-out ?","Pourrais-je avoir le mot de passe Wi-Fi ?","Avez-vous un service d’étage ?"]}

--- a/apps/sober-body/public/presets/hotel-pt-BR.json
+++ b/apps/sober-body/public/presets/hotel-pt-BR.json
@@ -1,0 +1,1 @@
+{"id":"preset-hotel-pt-BR","title":"Recepção de Hotel (PT-BR)","lang":"pt-BR","preset":true,"lines":["Tenho uma reserva em nome de...","O café da manhã está incluso?","Qual é o horário do check-out?","Pode me passar a senha do Wi-Fi?","Tem serviço de quarto?"]}

--- a/apps/sober-body/public/presets/restaurant-de-DE.json
+++ b/apps/sober-body/public/presets/restaurant-de-DE.json
@@ -1,0 +1,1 @@
+{"id":"preset-restaurant-de-DE","title":"Im Restaurant (DE-DE)","lang":"de-DE","preset":true,"lines":["Einen Tisch für zwei, bitte.","Könnten wir die Speisekarte sehen?","Was empfehlen Sie?","Ich bin allergisch gegen Nüsse.","Könnten wir bitte zahlen?"]}

--- a/apps/sober-body/public/presets/restaurant-en-US.json
+++ b/apps/sober-body/public/presets/restaurant-en-US.json
@@ -1,0 +1,1 @@
+{"id":"preset-restaurant-en-US","title":"At the Restaurant (EN-US)","lang":"en-US","preset":true,"lines":["A table for two, please.","Could we see the menu?","What do you recommend?","I’m allergic to nuts.","Could we get the bill, please?"]}

--- a/apps/sober-body/public/presets/restaurant-es-ES.json
+++ b/apps/sober-body/public/presets/restaurant-es-ES.json
@@ -1,0 +1,1 @@
+{"id":"preset-restaurant-es-ES","title":"En el Restaurante (ES-ES)","lang":"es-ES","preset":true,"lines":["Una mesa para dos, por favor.","¿Nos puede traer el menú?","¿Qué nos recomienda?","Soy alérgico a los frutos secos.","¿Nos trae la cuenta, por favor?"]}

--- a/apps/sober-body/public/presets/restaurant-fr-FR.json
+++ b/apps/sober-body/public/presets/restaurant-fr-FR.json
@@ -1,0 +1,1 @@
+{"id":"preset-restaurant-fr-FR","title":"Au Restaurant (FR-FR)","lang":"fr-FR","preset":true,"lines":["Une table pour deux, s’il vous plaît.","Pourrions-nous voir le menu ?","Qu’est-ce que vous recommandez ?","Je suis allergique aux noix.","L’addition, s’il vous plaît."]}

--- a/apps/sober-body/public/presets/restaurant-pt-BR.json
+++ b/apps/sober-body/public/presets/restaurant-pt-BR.json
@@ -1,0 +1,1 @@
+{"id":"preset-restaurant-pt-BR","title":"No Restaurante (PT-BR)","lang":"pt-BR","preset":true,"lines":["Uma mesa para dois, por favor.","Podemos ver o cardápio?","O que você recomenda?","Sou alérgico a nozes.","A conta, por favor."]}

--- a/apps/sober-body/public/presets/smalltalk-de-DE.json
+++ b/apps/sober-body/public/presets/smalltalk-de-DE.json
@@ -1,0 +1,1 @@
+{"id":"preset-smalltalk-de-DE","title":"Smalltalk (DE-DE)","lang":"de-DE","preset":true,"lines":["Wie war dein Wochenende?","Was machst du beruflich?","Hast du in letzter Zeit einen guten Film gesehen?","Das Wetter ist heute schön.","Es war schön, mit dir zu plaudern."]}

--- a/apps/sober-body/public/presets/smalltalk-en-US.json
+++ b/apps/sober-body/public/presets/smalltalk-en-US.json
@@ -1,0 +1,1 @@
+{"id":"preset-smalltalk-en-US","title":"Small Talk (EN-US)","lang":"en-US","preset":true,"lines":["How was your weekend?","What do you do for work?","Have you seen any good movies lately?","The weather is nice today.","It was great chatting with you."]}

--- a/apps/sober-body/public/presets/smalltalk-es-ES.json
+++ b/apps/sober-body/public/presets/smalltalk-es-ES.json
@@ -1,0 +1,1 @@
+{"id":"preset-smalltalk-es-ES","title":"Conversación Informal (ES-ES)","lang":"es-ES","preset":true,"lines":["¿Qué tal tu fin de semana?","¿A qué te dedicas?","¿Has visto alguna película buena últimamente?","Hace buen tiempo hoy.","Ha sido un placer charlar contigo."]}

--- a/apps/sober-body/public/presets/smalltalk-fr-FR.json
+++ b/apps/sober-body/public/presets/smalltalk-fr-FR.json
@@ -1,0 +1,1 @@
+{"id":"preset-smalltalk-fr-FR","title":"Petite Conversation (FR-FR)","lang":"fr-FR","preset":true,"lines":["Comment s’est passé ton week-end ?","Que fais-tu dans la vie ?","As-tu vu un bon film récemment ?","Il fait beau aujourd’hui.","Ravi d’avoir discuté avec toi."]}

--- a/apps/sober-body/public/presets/smalltalk-pt-BR.json
+++ b/apps/sober-body/public/presets/smalltalk-pt-BR.json
@@ -1,0 +1,1 @@
+{"id":"preset-smalltalk-pt-BR","title":"Conversa Informal (PT-BR)","lang":"pt-BR","preset":true,"lines":["Como foi seu fim de semana?","Com o que você trabalha?","Assistiu a algum filme bom recentemente?","O tempo está agradável hoje.","Foi ótimo conversar com você."]}

--- a/apps/sober-body/public/presets/taxi-de-DE.json
+++ b/apps/sober-body/public/presets/taxi-de-DE.json
@@ -1,0 +1,1 @@
+{"id":"preset-taxi-de-DE","title":"Im Taxi (DE-DE)","lang":"de-DE","preset":true,"lines":["Können Sie mich bei ... absetzen?","Wie lange dauert die Fahrt?","Können Sie das Taxameter einschalten?","Bitte nehmen Sie die schnellste Route.","Danke, behalten Sie das Wechselgeld."]}

--- a/apps/sober-body/public/presets/taxi-en-US.json
+++ b/apps/sober-body/public/presets/taxi-en-US.json
@@ -1,0 +1,1 @@
+{"id":"preset-taxi-en-US","title":"In the Taxi (EN-US)","lang":"en-US","preset":true,"lines":["Could you drop me at ...?","How long will the ride take?","Can you turn on the meter?","Please take the fastest route.","Thank you, keep the change."]}

--- a/apps/sober-body/public/presets/taxi-es-ES.json
+++ b/apps/sober-body/public/presets/taxi-es-ES.json
@@ -1,0 +1,1 @@
+{"id":"preset-taxi-es-ES","title":"En el Taxi (ES-ES)","lang":"es-ES","preset":true,"lines":["¿Me puede dejar en ...?","¿Cuánto tardará el viaje?","¿Puede poner el taxímetro?","Por favor, tome la ruta más rápida.","Gracias, quédese con el cambio."]}

--- a/apps/sober-body/public/presets/taxi-fr-FR.json
+++ b/apps/sober-body/public/presets/taxi-fr-FR.json
@@ -1,0 +1,1 @@
+{"id":"preset-taxi-fr-FR","title":"Dans le Taxi (FR-FR)","lang":"fr-FR","preset":true,"lines":["Pouvez-vous me déposer à ... ?","Le trajet prendra combien de temps ?","Pouvez-vous mettre le compteur ?","Prenez la route la plus rapide, s’il vous plaît.","Merci, gardez la monnaie."]}

--- a/apps/sober-body/public/presets/taxi-pt-BR.json
+++ b/apps/sober-body/public/presets/taxi-pt-BR.json
@@ -1,0 +1,1 @@
+{"id":"preset-taxi-pt-BR","title":"No Táxi (PT-BR)","lang":"pt-BR","preset":true,"lines":["Pode me deixar na ...?","Quanto tempo leva a corrida?","Pode ligar o taxímetro?","Por favor, pegue o caminho mais rápido.","Obrigado, fique com o troco."]}

--- a/apps/sober-body/src/App.tsx
+++ b/apps/sober-body/src/App.tsx
@@ -1,5 +1,7 @@
 import './App.css'
 import { Routes, Route } from 'react-router-dom'
+import { useEffect } from 'react'
+import { seedPresetDecks } from './features/games/deck-storage'
 import BacDashboard from './components/BacDashboard'
 import LandingPage from './components/LandingPage'
 import CoachPage from './pages/coach'
@@ -7,6 +9,9 @@ import { DrinkLogProvider } from './features/core/drink-context'
 import { SettingsProvider } from './features/core/settings-context'
 
 function App() {
+  useEffect(() => {
+    seedPresetDecks()
+  }, [])
   return (
     <SettingsProvider>
       <DrinkLogProvider>

--- a/apps/sober-body/src/components/PronunciationCoachUI.test.tsx
+++ b/apps/sober-body/src/components/PronunciationCoachUI.test.tsx
@@ -3,6 +3,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import 'fake-indexeddb/auto'
 import PronunciationCoachUI from './PronunciationCoachUI'
 import { SettingsProvider } from '../features/core/settings-context'
+import { DeckProvider } from '../features/games/deck-context'
 import { installSpeechMocks } from '../../test/utils/mockSpeech'
 
 vi.mock('../../../../packages/pronunciation-coach/src/useTranslation', () => ({
@@ -19,7 +20,9 @@ describe('PronunciationCoachUI translation', () => {
     Object.defineProperty(window, 'getSelection', { value: getSelection })
     render(
       <SettingsProvider>
-        <PronunciationCoachUI />
+        <DeckProvider>
+          <PronunciationCoachUI />
+        </DeckProvider>
       </SettingsProvider>
     )
     const langSelect = screen.getAllByLabelText(/Translate to/i)[0]
@@ -34,7 +37,9 @@ describe('PronunciationCoachUI translation', () => {
     Object.defineProperty(window, 'getSelection', { value: getSelection })
     render(
       <SettingsProvider>
-        <PronunciationCoachUI />
+        <DeckProvider>
+          <PronunciationCoachUI />
+        </DeckProvider>
       </SettingsProvider>
     )
     const langSelect = screen.getAllByLabelText(/Translate to/i)[0]

--- a/apps/sober-body/src/components/PronunciationCoachUI.tsx
+++ b/apps/sober-body/src/components/PronunciationCoachUI.tsx
@@ -3,6 +3,7 @@ import { usePronunciationCoach } from "../features/games/PronunciationCoach";
 import useTranslation from "../../../../packages/pronunciation-coach/src/useTranslation";
 import { LANGS } from "../../../../packages/pronunciation-coach/src/langs";
 import { useSettings } from "../features/core/settings-context";
+import SituationsModal from "./SituationsModal";
 
 type Scope = "Word" | "Line" | "Sentence" | "Paragraph" | "Full";
 
@@ -40,6 +41,7 @@ export default function PronunciationCoachUI() {
   const [index, setIndex] = useState(0);
   const [lookupWord, setLookupWord] = useState<string | null>(null);
   const [showTranslation, setShowTranslation] = useState(true);
+  const [showSituations, setShowSituations] = useState(false);
   const { settings, setSettings } = useSettings();
 
   useEffect(() => {
@@ -120,6 +122,9 @@ export default function PronunciationCoachUI() {
               ))}
             </select>
           </label>
+          <button onClick={() => setShowSituations(true)} className="border px-2 py-1">
+            🎒 Browse Situations
+          </button>
           <button onClick={() => setIndex(0)} className="border px-2 py-1">
             Restart Drill
           </button>
@@ -205,6 +210,7 @@ export default function PronunciationCoachUI() {
             </div>
           )}
       </section>
+      <SituationsModal open={showSituations} onClose={() => setShowSituations(false)} />
     </div>
   );
 }

--- a/apps/sober-body/src/components/SituationsModal.tsx
+++ b/apps/sober-body/src/components/SituationsModal.tsx
@@ -1,0 +1,27 @@
+import React from 'react'
+import { useDecks } from '../features/games/deck-context'
+
+export default function SituationsModal({ open, onClose }: { open: boolean; onClose: () => void }) {
+  const { decks, setActiveDeck } = useDecks()
+  if (!open) return null
+  const presets = decks.filter(d => d.preset)
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+      <div className="bg-white rounded-md p-4 w-80 max-h-[80vh] overflow-y-auto">
+        <h3 className="text-xl mb-4">Practice Packs</h3>
+        <ul className="grid grid-cols-2 gap-4">
+          {presets.map(d => (
+            <li
+              key={d.id}
+              className="border p-3 rounded hover:bg-sky-50 cursor-pointer"
+              onClick={() => { setActiveDeck(d.id); onClose() }}
+            >
+              <h4 className="font-medium">{d.title}</h4>
+              <p className="text-xs text-gray-500">{d.lines.length} phrases</p>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  )
+}

--- a/apps/sober-body/src/features/games/__tests__/deck-storage.test.ts
+++ b/apps/sober-body/src/features/games/__tests__/deck-storage.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import 'fake-indexeddb/auto'
+import { loadDecks, seedPresetDecks } from '../deck-storage'
+import { LANGS } from '../../../../../../packages/pronunciation-coach/src/langs'
+
+async function clearDB() {
+  const dbs = await indexedDB.databases?.()
+  if (dbs) await Promise.all(dbs.map(db => indexedDB.deleteDatabase(db.name!)))
+}
+
+describe('seedPresetDecks', () => {
+  beforeEach(async () => {
+    await clearDB()
+  })
+
+  it('seeds presets without duplication', async () => {
+    await seedPresetDecks()
+    const first = await loadDecks()
+    expect(first.length).toBeGreaterThanOrEqual(LANGS.length * 5)
+    await seedPresetDecks()
+    const second = await loadDecks()
+    expect(second.length).toBe(first.length)
+  })
+})

--- a/apps/sober-body/src/features/games/deck-context.tsx
+++ b/apps/sober-body/src/features/games/deck-context.tsx
@@ -1,0 +1,36 @@
+import React, { createContext, useContext, useEffect, useRef, useState } from 'react'
+import { Deck, loadDecks, saveDecks } from './deck-storage'
+
+export interface DeckValue {
+  decks: Deck[]
+  activeDeck: string | null
+  setActiveDeck: (id: string) => void
+}
+
+const DeckContext = createContext<DeckValue | undefined>(undefined)
+
+export function DeckProvider({ children }: { children: React.ReactNode }) {
+  const [decks, setDecks] = useState<Deck[]>([])
+  const [activeDeck, setActiveDeck] = useState<string | null>(null)
+  const loaded = useRef(false)
+  useEffect(() => {
+    loadDecks().then(d => {
+      setDecks(d)
+      loaded.current = true
+    })
+  }, [])
+  useEffect(() => {
+    if (loaded.current) saveDecks(decks)
+  }, [decks])
+  return (
+    <DeckContext.Provider value={{ decks, activeDeck, setActiveDeck }}>
+      {children}
+    </DeckContext.Provider>
+  )
+}
+
+export function useDecks() {
+  const ctx = useContext(DeckContext)
+  if (!ctx) throw new Error('useDecks must be used within DeckProvider')
+  return ctx
+}

--- a/apps/sober-body/src/features/games/deck-storage.ts
+++ b/apps/sober-body/src/features/games/deck-storage.ts
@@ -1,0 +1,32 @@
+import { get, set } from 'idb-keyval'
+
+export interface Deck {
+  id: string
+  title: string
+  lang: string
+  preset?: boolean
+  lines: string[]
+  created_at?: number
+}
+
+const KEY = 'pc_decks'
+
+export async function loadDecks(): Promise<Deck[]> {
+  return (await get(KEY)) ?? []
+}
+
+export async function saveDecks(arr: Deck[]): Promise<void> {
+  await set(KEY, arr)
+}
+
+const modules = import.meta.glob<{ default: Deck }>('/public/presets/*.json', { eager: true })
+const presets: Deck[] = Object.values(modules).map(m => m.default)
+
+export async function seedPresetDecks() {
+  const existing = await loadDecks()
+  const byId = new Set(existing.map(d => d.id))
+  const fresh = presets
+    .filter(p => !byId.has(p.id))
+    .map(p => ({ ...p, created_at: Date.now() }))
+  if (fresh.length) saveDecks([...existing, ...fresh])
+}

--- a/apps/sober-body/src/main.tsx
+++ b/apps/sober-body/src/main.tsx
@@ -4,12 +4,15 @@ import { BrowserRouter } from 'react-router-dom'
 import './index.css'
 import App from './App.tsx'
 import { ModalProvider } from './components/ModalContext'
+import { DeckProvider } from './features/games/deck-context'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <BrowserRouter>
       <ModalProvider>
-        <App />
+        <DeckProvider>
+          <App />
+        </DeckProvider>
       </ModalProvider>
     </BrowserRouter>
   </StrictMode>,


### PR DESCRIPTION
## Summary
- add language situation JSON presets
- seed preset decks on app start and store in IndexedDB
- show Situations modal with selectable packs
- enable deck context provider and integration with Coach UI
- document situations in README

## Testing
- `pnpm -r lint`
- `pnpm -r test`

------
https://chatgpt.com/codex/tasks/task_e_68609dd8df80832b9d4dd6b8b3b60d05