### PR TITLE
fix type-only import in deck context

### DIFF
--- a/apps/sober-body/src/features/games/deck-context.tsx
+++ b/apps/sober-body/src/features/games/deck-context.tsx
@@ -1,5 +1,6 @@
 import React, { createContext, useContext, useEffect, useRef, useState } from 'react'
-import { Deck, loadDecks, saveDecks } from './deck-storage'
+import { loadDecks, saveDecks } from './deck-storage'
+import type { Deck } from './deck-storage'
 
 export interface DeckValue {
   decks: Deck[]


### PR DESCRIPTION
## Summary
- fix Deck import so bundler doesn't expect a runtime export

## Testing
- `pnpm -r lint`
- `pnpm -r test`


------
https://chatgpt.com/codex/tasks/task_e_6860a3071798832ba619262eb8c59292