### PR TITLE
Implement deck schema v2 with tags and signatures

### DIFF
--- a/apps/sober-body/src/components/SituationsModal.tsx
+++ b/apps/sober-body/src/components/SituationsModal.tsx
@@ -5,7 +5,7 @@ import { useDecks } from '../features/games/deck-context'
 export default function SituationsModal({ open, onClose }: { open: boolean; onClose: () => void }) {
   const { decks, setActiveDeck } = useDecks()
   if (!open) return null
-  const presets = decks.filter(d => d.preset)
+  const presets = decks.filter(d => d.tags?.includes('official'))
   return createPortal(
     <div className="fixed inset-0 bg-black/30 backdrop-blur-sm flex items-center justify-center z-50">
       <div className="bg-white w-[28rem] max-h-[80vh] overflow-y-auto rounded-xl p-6 shadow-xl">

--- a/apps/sober-body/src/features/games/deck-context.tsx
+++ b/apps/sober-body/src/features/games/deck-context.tsx
@@ -1,6 +1,6 @@
 import React, { createContext, useContext, useEffect, useRef, useState } from 'react'
 import { loadDecks, saveDecks } from './deck-storage'
-import type { Deck } from './deck-storage'
+import type { Deck } from './deck-types'
 
 export interface DeckValue {
   decks: Deck[]

--- a/apps/sober-body/src/features/games/deck-storage.ts
+++ b/apps/sober-body/src/features/games/deck-storage.ts
@@ -1,18 +1,20 @@
 import { get, set } from 'idb-keyval'
+import type { Deck } from './deck-types'
 
-export interface Deck {
-  id: string
-  title: string
-  lang: string
-  preset?: boolean
-  lines: string[]
-  created_at?: number
+export function migrateDeck(d: any): Deck {
+  if (d.preset) {
+    delete d.preset
+    d.tags = [...(d.tags ?? []), 'official']
+  }
+  return d
 }
 
 const KEY = 'pc_decks'
 
 export async function loadDecks(): Promise<Deck[]> {
-  return (await get(KEY)) ?? []
+  const arr = (await get(KEY)) ?? []
+  arr.forEach(migrateDeck)
+  return arr
 }
 
 export async function saveDecks(arr: Deck[]): Promise<void> {
@@ -20,13 +22,13 @@ export async function saveDecks(arr: Deck[]): Promise<void> {
 }
 
 const modules = import.meta.glob<{ default: Deck }>('/src/presets/*.json', { eager: true })
-const presets: Deck[] = Object.values(modules).map(m => m.default)
+const presets: Deck[] = Object.values(modules).map(m => migrateDeck(m.default))
 
 export async function seedPresetDecks() {
   const existing = await loadDecks()
   const byId = new Set(existing.map(d => d.id))
   const fresh = presets
     .filter(p => !byId.has(p.id))
-    .map(p => ({ ...p, created_at: Date.now() }))
+    .map(p => ({ ...p, updated: Date.now() }))
   if (fresh.length) saveDecks([...existing, ...fresh])
 }

--- a/apps/sober-body/src/features/games/deck-types.ts
+++ b/apps/sober-body/src/features/games/deck-types.ts
@@ -1,0 +1,15 @@
+export interface Sig {
+  signer: string;           // e.g. "Sober-Body"
+  alg: 'ed25519';
+  value: string;            // base64
+}
+
+export interface Deck {
+  id: string;
+  title: string;
+  lang: string;             // BCP-47
+  lines: string[];
+  tags?: string[];          // NEW  e.g. ["topic:groceries", "official"]
+  sig?: Sig;                // NEW  optional
+  updated?: number;
+}

--- a/apps/sober-body/src/features/games/verify-sig.ts
+++ b/apps/sober-body/src/features/games/verify-sig.ts
@@ -1,0 +1,5 @@
+import type { Deck } from './deck-types'
+
+export function isSignedOfficial(deck: Deck): boolean {
+  return deck.tags?.includes('official') ?? false
+}

--- a/apps/sober-body/src/presets/groceries-pt-BR.json
+++ b/apps/sober-body/src/presets/groceries-pt-BR.json
@@ -1,1 +1,1 @@
-{"id":"preset-groceries-pt-BR","title":"No Mercado (PT-BR)","lang":"pt-BR","preset":true,"lines":["Onde fica a seção de laticínios?","Quanto custa por quilo?","Aceita cartão de crédito?","Pode pesar estas maçãs, por favor?","Tem sacolas reutilizáveis?"]}
+{"id":"preset-groceries-pt-BR","title":"No Mercado (PT-BR)","lang":"pt-BR","lines":["Onde fica a seção de laticínios?","Quanto custa por quilo?","Aceita cartão de crédito?","Pode pesar estas maçãs, por favor?","Tem sacolas reutilizáveis?"],"tags":["official","topic:groceries"]}

--- a/apps/sober-body/src/presets/hotel-pt-BR.json
+++ b/apps/sober-body/src/presets/hotel-pt-BR.json
@@ -1,1 +1,1 @@
-{"id":"preset-hotel-pt-BR","title":"Recepção de Hotel (PT-BR)","lang":"pt-BR","preset":true,"lines":["Tenho uma reserva em nome de...","O café da manhã está incluso?","Qual é o horário do check-out?","Pode me passar a senha do Wi-Fi?","Tem serviço de quarto?"]}
+{"id":"preset-hotel-pt-BR","title":"Recepção de Hotel (PT-BR)","lang":"pt-BR","lines":["Tenho uma reserva em nome de...","O café da manhã está incluso?","Qual é o horário do check-out?","Pode me passar a senha do Wi-Fi?","Tem serviço de quarto?"],"tags":["official","topic:hotel"]}

--- a/apps/sober-body/src/presets/restaurant-pt-BR.json
+++ b/apps/sober-body/src/presets/restaurant-pt-BR.json
@@ -1,1 +1,1 @@
-{"id":"preset-restaurant-pt-BR","title":"No Restaurante (PT-BR)","lang":"pt-BR","preset":true,"lines":["Uma mesa para dois, por favor.","Podemos ver o cardápio?","O que você recomenda?","Sou alérgico a nozes.","A conta, por favor."]}
+{"id":"preset-restaurant-pt-BR","title":"No Restaurante (PT-BR)","lang":"pt-BR","lines":["Uma mesa para dois, por favor.","Podemos ver o cardápio?","O que você recomenda?","Sou alérgico a nozes.","A conta, por favor."],"tags":["official","topic:restaurant"]}

--- a/apps/sober-body/src/presets/smalltalk-pt-BR.json
+++ b/apps/sober-body/src/presets/smalltalk-pt-BR.json
@@ -1,1 +1,1 @@
-{"id":"preset-smalltalk-pt-BR","title":"Conversa Informal (PT-BR)","lang":"pt-BR","preset":true,"lines":["Como foi seu fim de semana?","Com o que você trabalha?","Assistiu a algum filme bom recentemente?","O tempo está agradável hoje.","Foi ótimo conversar com você."]}
+{"id":"preset-smalltalk-pt-BR","title":"Conversa Informal (PT-BR)","lang":"pt-BR","lines":["Como foi seu fim de semana?","Com o que você trabalha?","Assistiu a algum filme bom recentemente?","O tempo está agradável hoje.","Foi ótimo conversar com você."],"tags":["official","topic:smalltalk"]}

--- a/apps/sober-body/src/presets/taxi-pt-BR.json
+++ b/apps/sober-body/src/presets/taxi-pt-BR.json
@@ -1,1 +1,1 @@
-{"id":"preset-taxi-pt-BR","title":"No Táxi (PT-BR)","lang":"pt-BR","preset":true,"lines":["Pode me deixar na ...?","Quanto tempo leva a corrida?","Pode ligar o taxímetro?","Por favor, pegue o caminho mais rápido.","Obrigado, fique com o troco."]}
+{"id":"preset-taxi-pt-BR","title":"No Táxi (PT-BR)","lang":"pt-BR","lines":["Pode me deixar na ...?","Quanto tempo leva a corrida?","Pode ligar o taxímetro?","Por favor, pegue o caminho mais rápido.","Obrigado, fique com o troco."],"tags":["official","topic:taxi"]}

--- a/apps/sober-body/test/deck-migration.test.ts
+++ b/apps/sober-body/test/deck-migration.test.ts
@@ -1,0 +1,11 @@
+import { describe, it, expect } from 'vitest'
+import { migrateDeck } from '../src/features/games/deck-storage'
+
+describe('migrateDeck', () => {
+  it('converts old preset flag to tags', () => {
+    const old: any = { id: 'x', title: 'Old', lang: 'en', lines: [], preset: true }
+    const migrated = migrateDeck(old)
+    expect(migrated.tags).toContain('official')
+    expect('preset' in migrated).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary
- add new deck types with tags and optional signatures
- migrate old decks in storage to new schema
- update preset JSONs to use tags instead of `preset`
- switch components to check the new tag
- add placeholder signature verification helper
- test deck migration

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6861bce79ad8832b86a177e98a2354af