### PR TITLE
feat(ui): topic chips & tag filter in Browse Situations

### DIFF
--- a/apps/sober-body/src/components/SituationsModal.test.tsx
+++ b/apps/sober-body/src/components/SituationsModal.test.tsx
@@ -1,0 +1,38 @@
+import { render, fireEvent, screen } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import 'fake-indexeddb/auto'
+import SituationsModal from './SituationsModal'
+import { DeckProvider } from '../features/games/deck-context'
+
+const decks = [
+  { id: '1', title: 'Hotel', lang: 'en', lines: ['a'], tags: ['official', 'topic:hotel'] },
+  { id: '2', title: 'Taxi', lang: 'en', lines: ['b'], tags: ['official', 'topic:taxi'] },
+]
+
+vi.mock('../features/games/deck-storage', () => ({
+  loadDecks: vi.fn(async () => decks),
+  saveDecks: vi.fn(),
+}))
+
+describe('SituationsModal topic filter', () => {
+  beforeEach(() => {
+    const div = document.createElement('div')
+    div.id = 'portal-root'
+    document.body.appendChild(div)
+  })
+  afterEach(() => {
+    document.getElementById('portal-root')?.remove()
+  })
+  it('filters decks by selected topic', async () => {
+    render(
+      <DeckProvider>
+        <SituationsModal open={true} onClose={() => {}} />
+      </DeckProvider>
+    )
+    await screen.findByText('Hotel')
+    fireEvent.click(screen.getByRole('button', { name: /hotel/i }))
+    expect(screen.queryByText('Taxi')).toBeNull()
+    fireEvent.click(screen.getByRole('button', { name: /hotel/i }))
+    expect(screen.getByText('Taxi')).toBeTruthy()
+  })
+})

--- a/apps/sober-body/src/components/SituationsModal.tsx
+++ b/apps/sober-body/src/components/SituationsModal.tsx
@@ -1,11 +1,15 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { createPortal } from 'react-dom'
 import { useDecks } from '../features/games/deck-context'
+import { getTopics } from '../features/games/get-topics'
 
 export default function SituationsModal({ open, onClose }: { open: boolean; onClose: () => void }) {
   const { decks, setActiveDeck } = useDecks()
+  const [selected, setSel] = useState<string | null>(null)
   if (!open) return null
   const presets = decks.filter(d => d.tags?.includes('official'))
+  const topics = getTopics(presets)
+  const visible = selected ? presets.filter(d => d.tags?.includes(selected)) : presets
   return createPortal(
     <div className="fixed inset-0 bg-black/30 backdrop-blur-sm flex items-center justify-center z-50">
       <div className="bg-white w-[28rem] max-h-[80vh] overflow-y-auto rounded-xl p-6 shadow-xl">
@@ -13,18 +17,36 @@ export default function SituationsModal({ open, onClose }: { open: boolean; onCl
         {presets.length === 0 ? (
           <p>Loading…</p>
         ) : (
-          <ul className="grid grid-cols-2 gap-4">
-            {presets.map(d => (
-              <li
-                key={d.id}
-                onClick={() => { setActiveDeck(d.id); onClose() }}
-                className="border rounded p-3 hover:bg-sky-50 cursor-pointer"
-              >
-                <h4 className="font-medium">{d.title}</h4>
-                <p className="text-xs text-gray-500">{d.lines.length} phrases</p>
-              </li>
-            ))}
-          </ul>
+          <>
+            <div className="flex gap-2 overflow-x-auto mb-4">
+              {topics.map(t => (
+                <button
+                  key={t}
+                  onClick={() => setSel(sel => sel === t ? null : t)}
+                  className={`px-2 py-1 rounded-full text-xs ${selected === t ? 'bg-sky-600 text-white' : 'bg-gray-200'}`}
+                >
+                  {t.slice(6)}
+                </button>
+              ))}
+            </div>
+            {visible.length === 0 && (
+              <p className="text-center text-sm text-gray-500 py-8">
+                No decks tagged <strong>{selected?.slice(6)}</strong>.
+              </p>
+            )}
+            <ul className="grid grid-cols-2 gap-4">
+              {visible.map(d => (
+                <li
+                  key={d.id}
+                  onClick={() => { setActiveDeck(d.id); onClose() }}
+                  className="border rounded p-3 hover:bg-sky-50 cursor-pointer"
+                >
+                  <h4 className="font-medium">{d.title}</h4>
+                  <p className="text-xs text-gray-500">{d.lines.length} phrases</p>
+                </li>
+              ))}
+            </ul>
+          </>
         )}
         <button className="absolute top-3 right-4" onClick={onClose}>✕</button>
       </div>

--- a/apps/sober-body/src/features/games/deck-storage.ts
+++ b/apps/sober-body/src/features/games/deck-storage.ts
@@ -1,6 +1,7 @@
 import { get, set } from 'idb-keyval'
 import type { Deck } from './deck-types'
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function migrateDeck(d: any): Deck {
   if (d.preset) {
     delete d.preset

--- a/apps/sober-body/src/features/games/get-topics.ts
+++ b/apps/sober-body/src/features/games/get-topics.ts
@@ -1,0 +1,9 @@
+import type { Deck } from './deck-types'
+
+export function getTopics(decks: Deck[]): string[] {
+  const set = new Set<string>()
+  decks.forEach(d => d.tags?.forEach(t => {
+    if (t.startsWith('topic:')) set.add(t)
+  }))
+  return Array.from(set).sort()
+}

--- a/apps/sober-body/test/deck-migration.test.ts
+++ b/apps/sober-body/test/deck-migration.test.ts
@@ -3,6 +3,7 @@ import { migrateDeck } from '../src/features/games/deck-storage'
 
 describe('migrateDeck', () => {
   it('converts old preset flag to tags', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const old: any = { id: 'x', title: 'Old', lang: 'en', lines: [], preset: true }
     const migrated = migrateDeck(old)
     expect(migrated.tags).toContain('official')


### PR DESCRIPTION
- implement `getTopics` to gather unique `topic:` tags
- show scrollable topic chip bar in `SituationsModal`
- filter deck grid by selected topic and show empty state
- unit test verifying topic filter logic
- add lint suppressions for existing `any` usage

All tests pass via `pnpm -r test`

------
https://chatgpt.com/codex/tasks/task_e_6861f12a9bc0832b88964b90db1b4b95