### PR TITLE
Add paste deck import modal

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,3 +62,7 @@ License information will be added in a future release. For questions, open an is
 
 The Coach now includes a simple Deck Manager for creating, editing and sharing custom phrase decks.
 ![Deck Manager screenshot](docs/images/deck-manager.png)
+
+### Authoring decks
+
+Paste a text list via **Import ⌘V** and each line becomes a phrase.

--- a/apps/sober-body/src/components/DeckManagerPage.tsx
+++ b/apps/sober-body/src/components/DeckManagerPage.tsx
@@ -2,10 +2,12 @@ import { useEffect, useState } from 'react'
 import { loadDecks, saveDeck, deleteDeck, exportDeck, importDeck } from '../features/games/deck-storage'
 import type { Deck } from '../features/games/deck-types'
 import DeckModal from './DeckModal'
+import PasteDeckModal from './PasteDeckModal'
 
 export default function DeckManagerPage() {
   const [decks, setDecks] = useState<Deck[]>([])
   const [edit, setEdit] = useState<Deck | null>(null)
+  const [paste, setPaste] = useState(false)
   const refresh = async () => {
     const arr = await loadDecks()
     arr.sort((a,b)=>(b.updated??0)-(a.updated??0))
@@ -29,6 +31,7 @@ export default function DeckManagerPage() {
           <label className="border px-2 cursor-pointer">
             Import JSON<input type="file" accept="application/json" className="hidden" onChange={e=>e.target.files&&handleFile(e.target.files[0])}/>
           </label>
+          <button className="border px-2" onClick={() => setPaste(true)}>Import ⌘V</button>
         </span>
       </h2>
       <ul className="space-y-2">
@@ -44,6 +47,7 @@ export default function DeckManagerPage() {
         ))}
       </ul>
       {edit && <DeckModal deck={edit} onSave={async d=>{await saveDeck(d);setEdit(null);refresh()}} onClose={()=>setEdit(null)} />}
+      {paste && <PasteDeckModal onSave={async d=>{await saveDeck(d);setPaste(false);refresh()}} onClose={()=>setPaste(false)} />}
     </div>
   )
 }

--- a/apps/sober-body/src/components/PasteDeckModal.tsx
+++ b/apps/sober-body/src/components/PasteDeckModal.tsx
@@ -1,0 +1,49 @@
+import { useState } from 'react'
+import { LANGS } from '../../../../packages/pronunciation-coach/src/langs'
+import type { Deck } from '../features/games/deck-types'
+
+export default function PasteDeckModal({ onSave, onClose }: { onSave: (d: Deck) => void; onClose: () => void }) {
+  const [title, setTitle] = useState('')
+  const [lang, setLang] = useState(LANGS[0].code)
+  const [tags, setTags] = useState('')
+  const [text, setText] = useState('')
+  const submit = () => {
+    const lines = text
+      .split(/\r?\n/)
+      .map(s => s.trim())
+      .filter(Boolean)
+    if (lines.length < 1) {
+      alert('Need at least one phrase')
+      return
+    }
+    const deck: Deck = {
+      id: crypto.randomUUID(),
+      title,
+      lang,
+      lines,
+      tags: tags.split(',').map(t => t.trim()).filter(Boolean),
+      updated: Date.now(),
+    }
+    onSave(deck)
+    onClose()
+    alert('Deck added!')
+  }
+  return (
+    <div className="fixed inset-0 bg-black/30 flex items-center justify-center z-50">
+      <div className="bg-white p-4 rounded space-y-2 w-80">
+        <input className="border w-full p-1" value={title} onChange={e => setTitle(e.target.value)} placeholder="Title" />
+        <select className="border w-full p-1" value={lang} onChange={e => setLang(e.target.value)}>
+          {LANGS.map(l => (
+            <option key={l.code} value={l.code}>{l.label}</option>
+          ))}
+        </select>
+        <input className="border w-full p-1" value={tags} onChange={e => setTags(e.target.value)} placeholder="tag1, tag2" />
+        <textarea className="border w-full h-32 p-1" value={text} onChange={e => setText(e.target.value)} placeholder="One phrase per line…" />
+        <div className="flex justify-end gap-2">
+          <button className="border px-2" onClick={submit}>Save</button>
+          <button className="border px-2" onClick={onClose}>Close</button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/sober-body/test/paste-deck.test.ts
+++ b/apps/sober-body/test/paste-deck.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import 'fake-indexeddb/auto'
+import { loadDecks, saveDeck } from '../src/features/games/deck-storage'
+import type { Deck } from '../src/features/games/deck-types'
+
+async function clearDB() {
+  const dbs = await indexedDB.databases?.()
+  if (dbs) await Promise.all(dbs.map(db => indexedDB.deleteDatabase(db.name!)))
+}
+
+describe('paste deck', () => {
+  beforeEach(async () => {
+    await clearDB()
+  })
+
+  it('creates deck from pasted text', async () => {
+    const text = 'line one\nline two'
+    const lines = text.split(/\r?\n/).map(s => s.trim()).filter(Boolean)
+    const deck: Deck = {
+      id: crypto.randomUUID(),
+      title: 'Paste',
+      lang: 'en',
+      lines,
+      tags: [],
+      updated: Date.now(),
+    }
+    await saveDeck(deck)
+    const decks = await loadDecks()
+    expect(decks[0].lines.length).toBe(2)
+  })
+})


### PR DESCRIPTION
## Summary
- add PasteDeckModal for quick text imports
- update DeckManagerPage with new Import ⌘V button
- document paste option in README
- test saving pasted decks

## Testing
- `pnpm -r lint`
- `pnpm --filter sober-body test`

------
https://chatgpt.com/codex/tasks/task_e_6862aa0df904832b977d6c9197cec223