### PR TITLE
feat/ui: chip input for deck tags

### DIFF
--- a/apps/sober-body/src/components/DeckModal.tsx
+++ b/apps/sober-body/src/components/DeckModal.tsx
@@ -1,27 +1,82 @@
-import { useState } from 'react'
-import { LANGS } from '../../../../packages/pronunciation-coach/src/langs'
-import type { Deck } from '../features/games/deck-types'
+import { useState } from "react";
+import { LANGS } from "../../../../packages/pronunciation-coach/src/langs";
+import type { Deck } from "../features/games/deck-types";
+import TagsInput from "./TagsInput";
 
-export default function DeckModal({ deck, onSave, onClose }: { deck: Deck; onSave: (d: Deck) => void; onClose: () => void }) {
-  const [d, setD] = useState(deck)
-  const ro = !!deck.sig
-  const upd = (f: Partial<Deck>) => setD(o => ({ ...o, ...f }))
+export default function DeckModal({
+  deck,
+  onSave,
+  onClose,
+}: {
+  deck: Deck;
+  onSave: (d: Deck) => void;
+  onClose: () => void;
+}) {
+  const [d, setD] = useState(deck);
+  const [tags, setTags] = useState(
+    (deck.tags ?? []).map((t) => (t.startsWith("topic:") ? t.slice(6) : t)),
+  );
+  const ro = !!deck.sig;
+  const upd = (f: Partial<Deck>) => setD((o) => ({ ...o, ...f }));
   return (
     <div className="fixed inset-0 bg-black/30 flex items-center justify-center z-50">
       <div className="bg-white p-4 rounded space-y-2 w-80">
-        <input className="border w-full p-1" disabled={ro} value={d.title} onChange={e => upd({ title: e.target.value })} />
-        <select className="border w-full p-1" disabled={ro} value={d.lang} onChange={e => upd({ lang: e.target.value })}>
-          {LANGS.map(l => (
-            <option key={l.code} value={l.code}>{l.label}</option>
+        <input
+          className="border w-full p-1"
+          disabled={ro}
+          value={d.title}
+          onChange={(e) => upd({ title: e.target.value })}
+        />
+        <select
+          className="border w-full p-1"
+          disabled={ro}
+          value={d.lang}
+          onChange={(e) => upd({ lang: e.target.value })}
+        >
+          {LANGS.map((l) => (
+            <option key={l.code} value={l.code}>
+              {l.label}
+            </option>
           ))}
         </select>
-        <input className="border w-full p-1" disabled={ro} value={(d.tags ?? []).join(' ')} onChange={e => upd({ tags: e.target.value.split(/\s+/).filter(Boolean) })} />
-        <textarea className="border w-full h-32 p-1" disabled={ro} value={d.lines.join('\n')} onChange={e => upd({ lines: e.target.value.split(/\r?\n/).filter(Boolean) })} />
+        {ro ? (
+          <input
+            className="border w-full p-1"
+            disabled
+            value={tags.join(" ")}
+          />
+        ) : (
+          <TagsInput tags={tags} setTags={setTags} />
+        )}
+        <textarea
+          className="border w-full h-32 p-1"
+          disabled={ro}
+          value={d.lines.join("\n")}
+          onChange={(e) =>
+            upd({ lines: e.target.value.split(/\r?\n/).filter(Boolean) })
+          }
+        />
         <div className="flex justify-end gap-2">
-          {!ro && <button className="border px-2" onClick={() => onSave(d)}>Save</button>}
-          <button className="border px-2" onClick={onClose}>Close</button>
+          {!ro && (
+            <button
+              className="border px-2"
+              onClick={() =>
+                onSave({
+                  ...d,
+                  tags: tags.map((t) =>
+                    t.startsWith("topic:") ? t : `topic:${t}`,
+                  ),
+                })
+              }
+            >
+              Save
+            </button>
+          )}
+          <button className="border px-2" onClick={onClose}>
+            Close
+          </button>
         </div>
       </div>
     </div>
-  )
+  );
 }

--- a/apps/sober-body/src/components/PasteDeckModal.tsx
+++ b/apps/sober-body/src/components/PasteDeckModal.tsx
@@ -1,49 +1,76 @@
-import { useState } from 'react'
-import { LANGS } from '../../../../packages/pronunciation-coach/src/langs'
-import type { Deck } from '../features/games/deck-types'
+import { useState } from "react";
+import { LANGS } from "../../../../packages/pronunciation-coach/src/langs";
+import type { Deck } from "../features/games/deck-types";
+import TagsInput from "./TagsInput";
 
-export default function PasteDeckModal({ onSave, onClose }: { onSave: (d: Deck) => void; onClose: () => void }) {
-  const [title, setTitle] = useState('')
-  const [lang, setLang] = useState(LANGS[0].code)
-  const [tags, setTags] = useState('')
-  const [text, setText] = useState('')
+export default function PasteDeckModal({
+  onSave,
+  onClose,
+}: {
+  onSave: (d: Deck) => void;
+  onClose: () => void;
+}) {
+  const [title, setTitle] = useState("");
+  const [lang, setLang] = useState(LANGS[0].code);
+  const [tags, setTags] = useState<string[]>([]);
+  const [text, setText] = useState("");
   const submit = () => {
     const lines = text
       .split(/\r?\n/)
-      .map(s => s.trim())
-      .filter(Boolean)
+      .map((s) => s.trim())
+      .filter(Boolean);
     if (lines.length < 1) {
-      alert('Need at least one phrase')
-      return
+      alert("Need at least one phrase");
+      return;
     }
     const deck: Deck = {
       id: crypto.randomUUID(),
       title,
       lang,
       lines,
-      tags: tags.split(',').map(t => t.trim()).filter(Boolean),
+      tags: tags.map((t) => (t.startsWith("topic:") ? t : `topic:${t}`)),
       updated: Date.now(),
-    }
-    onSave(deck)
-    onClose()
-    alert('Deck added!')
-  }
+    };
+    onSave(deck);
+    onClose();
+    alert("Deck added!");
+  };
   return (
     <div className="fixed inset-0 bg-black/30 flex items-center justify-center z-50">
       <div className="bg-white p-4 rounded space-y-2 w-80">
-        <input className="border w-full p-1" value={title} onChange={e => setTitle(e.target.value)} placeholder="Title" />
-        <select className="border w-full p-1" value={lang} onChange={e => setLang(e.target.value)}>
-          {LANGS.map(l => (
-            <option key={l.code} value={l.code}>{l.label}</option>
+        <input
+          className="border w-full p-1"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          placeholder="Title"
+        />
+        <select
+          className="border w-full p-1"
+          value={lang}
+          onChange={(e) => setLang(e.target.value)}
+        >
+          {LANGS.map((l) => (
+            <option key={l.code} value={l.code}>
+              {l.label}
+            </option>
           ))}
         </select>
-        <input className="border w-full p-1" value={tags} onChange={e => setTags(e.target.value)} placeholder="tag1, tag2" />
-        <textarea className="border w-full h-32 p-1" value={text} onChange={e => setText(e.target.value)} placeholder="One phrase per line…" />
+        <TagsInput tags={tags} setTags={setTags} />
+        <textarea
+          className="border w-full h-32 p-1"
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+          placeholder="One phrase per line…"
+        />
         <div className="flex justify-end gap-2">
-          <button className="border px-2" onClick={submit}>Save</button>
-          <button className="border px-2" onClick={onClose}>Close</button>
+          <button className="border px-2" onClick={submit}>
+            Save
+          </button>
+          <button className="border px-2" onClick={onClose}>
+            Close
+          </button>
         </div>
       </div>
     </div>
-  )
+  );
 }

--- a/apps/sober-body/src/components/TagsInput.tsx
+++ b/apps/sober-body/src/components/TagsInput.tsx
@@ -1,0 +1,36 @@
+import React, { useState } from "react";
+
+export default function TagsInput({
+  tags,
+  setTags,
+}: {
+  tags: string[];
+  setTags: (t: string[]) => void;
+}) {
+  const [draft, setDraft] = useState("");
+  const add = () => {
+    const val = draft.trim();
+    if (!val) return;
+    if (!tags.includes(val)) setTags([...tags, val]);
+    setDraft("");
+  };
+  return (
+    <div className="flex flex-wrap gap-1 border p-2 rounded">
+      {tags.map((t) => (
+        <span key={t} className="bg-sky-100 px-2 py-0.5 rounded-full text-xs">
+          {t}{" "}
+          <button onClick={() => setTags(tags.filter((x) => x !== t))}>
+            ×
+          </button>
+        </span>
+      ))}
+      <input
+        value={draft}
+        onChange={(e) => setDraft(e.target.value)}
+        onKeyDown={(e) => e.key === "Enter" && add()}
+        placeholder="Type tag and press Enter (e.g. groceries, A1, travel)"
+        className="flex-1 min-w-[6rem] text-xs focus:outline-none"
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add `TagsInput` chip component
- use `TagsInput` in deck modals
- auto-prefix entered tags with `topic:` when saving

## Testing
- `pnpm -r lint`
- `pnpm -r test`


------
https://chatgpt.com/codex/tasks/task_e_6862b6f8cfcc832b909d1c7d187607f2