### PR TITLE
Enhance coach UI accessibility

### DIFF
--- a/apps/sober-body/src/components/DeckManagerPage.tsx
+++ b/apps/sober-body/src/components/DeckManagerPage.tsx
@@ -57,6 +57,7 @@ export default function DeckManagerPage() {
               }}
               className="text-sky-600 text-lg"
               title="Start drill"
+              aria-label="Start drill"
             >
               ▶
             </button>
@@ -69,6 +70,7 @@ export default function DeckManagerPage() {
             {!deck.sig && (
               <button
                 title="Edit"
+                aria-label="Edit deck"
                 onClick={() => setEdit(deck)}
                 className="text-xs"
               >
@@ -77,6 +79,7 @@ export default function DeckManagerPage() {
             )}
             <button
               title="Download"
+              aria-label="Download deck"
               onClick={() => download(deck)}
               className="text-xs"
             >
@@ -85,6 +88,7 @@ export default function DeckManagerPage() {
             {!deck.sig && (
               <button
                 title="Delete"
+                aria-label="Delete deck"
                 onClick={async () => {
                   await deleteDeck(deck.id)
                   refresh()

--- a/apps/sober-body/src/components/PronunciationCoachUI.tsx
+++ b/apps/sober-body/src/components/PronunciationCoachUI.tsx
@@ -174,7 +174,14 @@ export default function PronunciationCoachUI() {
           {current}
         </h2>
         <div className="flex gap-4 mb-8">
-            <button onClick={coach.play}>▶ Play</button>
+            <button
+              onClick={coach.play}
+              title="Play sample"
+              aria-label="Play sample"
+              className="px-3 py-1 text-lg"
+            >
+              ▶ Play
+            </button>
             <button
               disabled={
                 !(
@@ -183,6 +190,9 @@ export default function PronunciationCoachUI() {
                 )
               }
               onClick={coach.recording ? coach.stop : coach.start}
+              title={coach.recording ? "Stop recording" : "Record your voice"}
+              aria-label={coach.recording ? "Stop recording" : "Record your voice"}
+              className="px-3 py-1 text-lg"
             >
               {coach.recording ? "■ Stop" : "⏺ Record"}
             </button>
@@ -199,7 +209,14 @@ export default function PronunciationCoachUI() {
         {translation && showTranslation && (
             <div className="flex items-center gap-2 mb-8 rounded-md border px-4 py-2 bg-white/90 shadow max-w-xs text-sm">
               <span>{translation}</span>
-              <button onClick={speak}>🔊</button>
+              <button
+                onClick={speak}
+                title="Hear translation"
+                aria-label="Hear translation"
+                className="ml-2 text-lg"
+              >
+                🔊
+              </button>
             </div>
           )}
         {deck.length > 0 && (

--- a/apps/sober-body/src/components/TagsInput.tsx
+++ b/apps/sober-body/src/components/TagsInput.tsx
@@ -19,7 +19,10 @@ export default function TagsInput({
       {tags.map((t) => (
         <span key={t} className="bg-sky-100 px-2 py-0.5 rounded-full text-xs">
           {t}{" "}
-          <button onClick={() => setTags(tags.filter((x) => x !== t))}>
+          <button
+            onClick={() => setTags(tags.filter((x) => x !== t))}
+            aria-label="Remove tag"
+          >
             ×
           </button>
         </span>
@@ -27,7 +30,14 @@ export default function TagsInput({
       <input
         value={draft}
         onChange={(e) => setDraft(e.target.value)}
-        onKeyDown={(e) => e.key === "Enter" && add()}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") {
+            e.preventDefault();
+            add();
+          } else if (e.key === "Backspace" && draft === "") {
+            setTags(tags.slice(0, -1));
+          }
+        }}
         placeholder="Type tag and press Enter (e.g. groceries, A1, travel)"
         className="flex-1 min-w-[6rem] text-xs focus:outline-none"
       />


### PR DESCRIPTION
## Summary
- improve coach control buttons with titles, aria-labels and larger icons
- update deck manager icons with aria labels
- support backspace delete in `TagsInput`

## Testing
- `pnpm -r --parallel test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862bb99dae0832ba8dbaeb97d9868a5