### PR TITLE
Fix translation button test

### DIFF
--- a/apps/sober-body/src/components/PronunciationCoachUI.test.tsx
+++ b/apps/sober-body/src/components/PronunciationCoachUI.test.tsx
@@ -53,7 +53,7 @@ describe('PronunciationCoachUI translation', () => {
     await screen.findAllByText('bonjour')
     fireEvent.click(screen.getAllByLabelText(/Slow speak/i)[0])
     await Promise.resolve()
-    fireEvent.click(screen.getAllByRole('button', { name: '🔊' })[0])
+    fireEvent.click(screen.getAllByRole('button', { name: /Hear translation/i })[0])
     const speakMock = speechSynthesis.speak as unknown as vi.Mock
     const utter = speakMock.mock.calls[speakMock.mock.calls.length - 1][0] as SpeechSynthesisUtterance
     expect(utter.rate).toBe(0.7)


### PR DESCRIPTION
## Summary
- adjust query in PronunciationCoachUI test to use accessible name

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6862bd32c148832baa9a6510b0aa8fb2