### PR TITLE
Load selected deck via query param

### DIFF
--- a/apps/sober-body/src/components/DeckManagerPage.tsx
+++ b/apps/sober-body/src/components/DeckManagerPage.tsx
@@ -51,10 +51,7 @@ export default function DeckManagerPage() {
             className="flex items-center gap-3 border rounded px-3 py-2 hover:bg-sky-50"
           >
             <button
-              onClick={() => {
-                setActiveDeck(deck.id)
-                navigate('/coach')
-              }}
+              onClick={() => navigate(`/coach?deck=${deck.id}`)}
               className="text-sky-600 text-lg"
               title="Start drill"
               aria-label="Start drill"

--- a/apps/sober-body/src/pages/__tests__/coach.test.tsx
+++ b/apps/sober-body/src/pages/__tests__/coach.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import { describe, it, expect, vi } from 'vitest'
+import 'fake-indexeddb/auto'
+import CoachPage from '../coach'
+import { DeckProvider, useDecks } from '../../features/games/deck-context'
+import { SettingsProvider } from '../../features/core/settings-context'
+
+const decks = [
+  { id: 'abc', title: 'Test', lang: 'en', lines: ['x'], tags: [] as string[] }
+]
+
+vi.mock('../../features/games/deck-storage', () => ({
+  loadDecks: vi.fn(async () => decks),
+  saveDecks: vi.fn(),
+}))
+
+function ActiveDisplay() {
+  const { activeDeck } = useDecks()
+  return <div data-testid="active">{activeDeck}</div>
+}
+
+describe('CoachPage routing', () => {
+  it('sets active deck from query param', async () => {
+    render(
+      <MemoryRouter initialEntries={['/coach?deck=abc']}>
+        <SettingsProvider>
+          <DeckProvider>
+            <Routes>
+              <Route path="/coach" element={<><CoachPage /><ActiveDisplay /></>} />
+            </Routes>
+          </DeckProvider>
+        </SettingsProvider>
+      </MemoryRouter>
+    )
+    await waitFor(() => {
+      expect(screen.getByTestId('active').textContent).toBe('abc')
+    })
+  })
+})

--- a/apps/sober-body/src/pages/coach.tsx
+++ b/apps/sober-body/src/pages/coach.tsx
@@ -1,4 +1,22 @@
+import { useEffect } from 'react'
+import { useSearchParams } from 'react-router-dom'
 import PronunciationCoachUI from '../components/PronunciationCoachUI'
+import { useDecks } from '../features/games/deck-context'
+
 export default function CoachPage() {
+  const [params] = useSearchParams()
+  const deckId = params.get('deck')
+  const { decks, setActiveDeck } = useDecks()
+
+  useEffect(() => {
+    if (deckId) {
+      if (decks.find(d => d.id === deckId)) {
+        setActiveDeck(deckId)
+      } else {
+        console.warn('Unknown deck id in URL, falling back.')
+      }
+    }
+  }, [deckId, setActiveDeck, decks])
+
   return <PronunciationCoachUI />
 }


### PR DESCRIPTION
## Summary
- navigate to Coach with the selected deck id via query string
- read deck id from URL in Coach page and activate it
- test that query param sets the active deck

## Testing
- `pnpm --filter sober-body test`

------
https://chatgpt.com/codex/tasks/task_e_6862bfc98eec832bb2e1f41b4b292c88