### PR TITLE
fix(router): load deck after hydration

### DIFF
--- a/apps/sober-body/src/components/DeckManagerPage.tsx
+++ b/apps/sober-body/src/components/DeckManagerPage.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { useDecks } from '../features/games/deck-context'
 import {
   loadDecks,
   saveDeck,
@@ -17,7 +16,6 @@ export default function DeckManagerPage() {
   const [edit, setEdit] = useState<Deck | null>(null)
   const [paste, setPaste] = useState(false)
   const navigate = useNavigate()
-  const { setActiveDeck } = useDecks()
   const refresh = async () => {
     const arr = await loadDecks()
     arr.sort((a,b)=>(b.updated??0)-(a.updated??0))

--- a/apps/sober-body/src/pages/__tests__/coach.test.tsx
+++ b/apps/sober-body/src/pages/__tests__/coach.test.tsx
@@ -37,4 +37,23 @@ describe('CoachPage routing', () => {
       expect(screen.getByTestId('active').textContent).toBe('abc')
     })
   })
+
+  it('loads deck from URL once decks are ready', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    render(
+      <MemoryRouter initialEntries={['/coach?deck=abc']}>
+        <SettingsProvider>
+          <DeckProvider>
+            <Routes>
+              <Route path="/coach" element={<><CoachPage /><ActiveDisplay /></>} />
+            </Routes>
+          </DeckProvider>
+        </SettingsProvider>
+      </MemoryRouter>
+    )
+    const nodes = await screen.findAllByTestId('active')
+    expect(nodes[0].textContent).toBe('abc')
+    expect(warn).not.toHaveBeenCalled()
+    warn.mockRestore()
+  })
 })

--- a/apps/sober-body/src/pages/coach.tsx
+++ b/apps/sober-body/src/pages/coach.tsx
@@ -5,18 +5,19 @@ import { useDecks } from '../features/games/deck-context'
 
 export default function CoachPage() {
   const [params] = useSearchParams()
-  const deckId = params.get('deck')
+  const requestedId = params.get('deck')
   const { decks, setActiveDeck } = useDecks()
 
   useEffect(() => {
-    if (deckId) {
-      if (decks.find(d => d.id === deckId)) {
-        setActiveDeck(deckId)
-      } else {
-        console.warn('Unknown deck id in URL, falling back.')
-      }
+    if (!requestedId) return
+    if (decks.find(d => d.id === requestedId)) {
+      setActiveDeck(requestedId)
     }
-  }, [deckId, setActiveDeck, decks])
+  }, [requestedId, decks, setActiveDeck])
+
+  if (requestedId && decks.length && !decks.some(d => d.id === requestedId)) {
+    console.warn('Deck ID from URL not found; using default.')
+  }
 
   return <PronunciationCoachUI />
 }


### PR DESCRIPTION
## Summary
- wait for DeckProvider hydration before setting the active deck
- drop unused hook in DeckManagerPage
- warn only if deck id missing
- cover deck-loading path in tests

## Testing
- `pnpm -r lint`
- `pnpm -r test`


------
https://chatgpt.com/codex/tasks/task_e_6862c52401fc832baca5c7932459b039