### PR TITLE
ensure Coach UI updates when activeDeck changes

### DIFF
--- a/apps/sober-body/src/components/PronunciationCoachUI.test.tsx
+++ b/apps/sober-body/src/components/PronunciationCoachUI.test.tsx
@@ -1,11 +1,21 @@
-import { render, fireEvent, screen } from '@testing-library/react'
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, fireEvent, screen, cleanup } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { useEffect } from 'react'
 import 'fake-indexeddb/auto'
 import PronunciationCoachUI from './PronunciationCoachUI'
 import { MemoryRouter } from 'react-router-dom'
 import { SettingsProvider } from '../features/core/settings-context'
-import { DeckProvider } from '../features/games/deck-context'
+import { DeckProvider, useDecks } from '../features/games/deck-context'
 import { installSpeechMocks } from '../../test/utils/mockSpeech'
+
+import type { Deck } from '../features/games/deck-types'
+
+const mockDecks: Deck[] = []
+
+vi.mock('../features/games/deck-storage', () => ({
+  loadDecks: vi.fn(async () => mockDecks),
+  saveDecks: vi.fn(),
+}))
 
 vi.mock('../../../../packages/pronunciation-coach/src/useTranslation', () => ({
   default: vi.fn(() => 'bonjour')
@@ -13,6 +23,10 @@ vi.mock('../../../../packages/pronunciation-coach/src/useTranslation', () => ({
 
 beforeEach(() => {
   installSpeechMocks()
+})
+
+afterEach(() => {
+  cleanup()
 })
 
 describe('PronunciationCoachUI translation', () => {
@@ -57,6 +71,43 @@ describe('PronunciationCoachUI translation', () => {
     const speakMock = speechSynthesis.speak as unknown as vi.Mock
     const utter = speakMock.mock.calls[speakMock.mock.calls.length - 1][0] as SpeechSynthesisUtterance
     expect(utter.rate).toBe(0.7)
+  })
+})
+
+describe('PronunciationCoachUI deck switching', () => {
+  it('resets index when active deck changes', async () => {
+    mockDecks.splice(0, mockDecks.length,
+      { id: 'a', title: 'A', lang: 'en', lines: ['a one', 'a two'], tags: [] },
+      { id: 'b', title: 'B', lang: 'en', lines: ['b one', 'b two'], tags: [] },
+    )
+
+    function Wrapper() {
+      const { setActiveDeck } = useDecks()
+      useEffect(() => { setActiveDeck('a') }, [setActiveDeck])
+      return (
+        <>
+          <button onClick={() => setActiveDeck('b')} data-testid="swap">swap</button>
+          <PronunciationCoachUI />
+        </>
+      )
+    }
+
+    render(
+      <MemoryRouter>
+        <SettingsProvider>
+          <DeckProvider>
+            <Wrapper />
+          </DeckProvider>
+        </SettingsProvider>
+      </MemoryRouter>
+    )
+
+    await screen.findAllByText('a one')
+    fireEvent.click(screen.getByRole('button', { name: 'Next' }))
+    fireEvent.click(screen.getByTestId('swap'))
+    await screen.findAllByText('b one')
+    const prev = screen.getByRole('button', { name: 'Prev' }) as HTMLButtonElement
+    expect(prev.disabled).toBe(true)
   })
 })
 

--- a/apps/sober-body/src/pages/coach.tsx
+++ b/apps/sober-body/src/pages/coach.tsx
@@ -6,14 +6,14 @@ import { useDecks } from '../features/games/deck-context'
 export default function CoachPage() {
   const [params] = useSearchParams()
   const requestedId = params.get('deck')
-  const { decks, setActiveDeck } = useDecks()
+  const { decks, setActiveDeck, activeDeck } = useDecks()
 
   useEffect(() => {
-    if (!requestedId) return
-    if (decks.find(d => d.id === requestedId)) {
+    if (!requestedId || !decks.length) return
+    if (requestedId !== activeDeck && decks.some(d => d.id === requestedId)) {
       setActiveDeck(requestedId)
     }
-  }, [requestedId, decks, setActiveDeck])
+  }, [requestedId, decks, activeDeck, setActiveDeck])
 
   if (requestedId && decks.length && !decks.some(d => d.id === requestedId)) {
     console.warn('Deck ID from URL not found; using default.')


### PR DESCRIPTION
## Summary
- reset drill index when switching decks
- delay setting active deck until decks load
- test deck switching logic in PronunciationCoachUI

## Testing
- `pnpm --filter sober-body test`

------
https://chatgpt.com/codex/tasks/task_e_6862c966387c832b927b02c9fd665601