### PR TITLE
seed ‘Groceries’ & ‘Hotel Reception’ decks (EN · PT-BR · ES · FR · DE)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ pnpm run dev
 
 You can practice quickly via 🎒 Situations.
 
+🚀 Try it: Manage Decks → Browse Situations → Groceries (PT-BR)
+
 Create a `.env.local` file at the repository root with your translation API
 credentials. All workspaces load environment variables from that shared file:
 

--- a/apps/sober-body/src/features/games/__tests__/deck-presets.test.ts
+++ b/apps/sober-body/src/features/games/__tests__/deck-presets.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import 'fake-indexeddb/auto'
+import { seedPresetDecks, loadDecks } from '../deck-storage'
+
+async function clearDB() {
+  const dbs = await indexedDB.databases?.()
+  if (dbs) await Promise.all(dbs.map(db => indexedDB.deleteDatabase(db.name!)))
+}
+
+describe('preset deck seeding', () => {
+  beforeEach(async () => {
+    await clearDB()
+  })
+
+  it('loads groceries and hotel presets', async () => {
+    await seedPresetDecks()
+    const decks = await loadDecks()
+    expect(decks.some(d => d.id === 'preset-groceries-en')).toBe(true)
+    expect(decks.some(d => d.tags?.includes('topic:hotel'))).toBe(true)
+  })
+})

--- a/apps/sober-body/src/presets/groceries-de.json
+++ b/apps/sober-body/src/presets/groceries-de.json
@@ -1,0 +1,1 @@
+{"id":"preset-groceries-de","title":"Groceries (DE)","lang":"de","tags":["official","topic:groceries"],"lines":["Wo finde ich die Milchprodukteabteilung?","Wie viel kostet es pro Kilo?","Nehmen Sie Kreditkarten?","Können Sie diese Äpfel bitte wiegen?","Haben Sie wiederverwendbare Taschen?"]}

--- a/apps/sober-body/src/presets/groceries-en.json
+++ b/apps/sober-body/src/presets/groceries-en.json
@@ -1,0 +1,1 @@
+{"id":"preset-groceries-en","title":"Groceries (EN)","lang":"en","tags":["official","topic:groceries"],"lines":["Where is the dairy section?","How much does it cost per kilo?","Do you take credit cards?","Could you weigh these apples, please?","Do you have reusable bags?"]}

--- a/apps/sober-body/src/presets/groceries-es.json
+++ b/apps/sober-body/src/presets/groceries-es.json
@@ -1,0 +1,1 @@
+{"id":"preset-groceries-es","title":"Groceries (ES)","lang":"es","tags":["official","topic:groceries"],"lines":["¿Dónde está la sección de lácteos?","¿Cuánto cuesta por kilo?","¿Aceptan tarjeta de crédito?","¿Podría pesar estas manzanas, por favor?","¿Tienen bolsas reutilizables?"]}

--- a/apps/sober-body/src/presets/groceries-fr.json
+++ b/apps/sober-body/src/presets/groceries-fr.json
@@ -1,0 +1,1 @@
+{"id":"preset-groceries-fr","title":"Groceries (FR)","lang":"fr","tags":["official","topic:groceries"],"lines":["Où est le rayon des produits laitiers ?","Combien ça coûte au kilo ?","Acceptez-vous la carte de crédit ?","Pouvez-vous peser ces pommes, s’il vous plaît ?","Avez-vous des sacs réutilisables ?"]}

--- a/apps/sober-body/src/presets/hotel-de.json
+++ b/apps/sober-body/src/presets/hotel-de.json
@@ -1,0 +1,1 @@
+{"id":"preset-hotel-de","title":"Hotel Reception (DE)","lang":"de","tags":["official","topic:hotel"],"lines":["Ich habe eine Reservierung auf den Namen...","Ist das Frühstück inbegriffen?","Wann ist Check-out?","Könnte ich das WLAN-Passwort bekommen?","Haben Sie Zimmerservice?"]}

--- a/apps/sober-body/src/presets/hotel-en.json
+++ b/apps/sober-body/src/presets/hotel-en.json
@@ -1,0 +1,1 @@
+{"id":"preset-hotel-en","title":"Hotel Reception (EN)","lang":"en","tags":["official","topic:hotel"],"lines":["I have a reservation under...","Is breakfast included?","What time is check-out?","Could I get the Wi-Fi password?","Do you have room service?"]}

--- a/apps/sober-body/src/presets/hotel-es.json
+++ b/apps/sober-body/src/presets/hotel-es.json
@@ -1,0 +1,1 @@
+{"id":"preset-hotel-es","title":"Hotel Reception (ES)","lang":"es","tags":["official","topic:hotel"],"lines":["Tengo una reserva a nombre de...","¿El desayuno está incluido?","¿A qué hora es el check-out?","¿Me puede dar la contraseña del Wi-Fi?","¿Tienen servicio de habitaciones?"]}

--- a/apps/sober-body/src/presets/hotel-fr.json
+++ b/apps/sober-body/src/presets/hotel-fr.json
@@ -1,0 +1,1 @@
+{"id":"preset-hotel-fr","title":"Hotel Reception (FR)","lang":"fr","tags":["official","topic:hotel"],"lines":["J’ai une réservation au nom de...","Le petit-déjeuner est-il inclus ?","À quelle heure est le check-out ?","Pourrais-je avoir le mot de passe Wi-Fi ?","Avez-vous un service d’étage ?"]}


### PR DESCRIPTION
## Summary
- add Groceries & Hotel decks for EN, ES, FR, DE
- expose them via preset JSON files
- document how to try Browse Situations
- test preset loading for Groceries/Hotel decks

## Testing
- `pnpm --filter sober-body test`

------
https://chatgpt.com/codex/tasks/task_e_6862d32039f8832bae09f06b166b4f2e