### PR TITLE
Add folder import for decks

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,3 +67,4 @@ Decks are organised by `cat:<topic>` tags. Filter chips appear automatically whe
 ### Authoring decks
 
 Paste a text list via **Import ⌘V** and each line becomes a phrase.
+You can bulk-import a folder of JSON decks via **Import folder** (Chrome/Edge/Safari only).

--- a/apps/sober-body/src/components/DeckManagerPage.tsx
+++ b/apps/sober-body/src/components/DeckManagerPage.tsx
@@ -6,6 +6,7 @@ import {
   deleteDeck,
   exportDeck,
   importDeck,
+  importDeckFiles,
 } from '../features/games/deck-storage'
 import { getCategories } from '../features/games/get-categories'
 import type { Deck } from '../features/games/deck-types'
@@ -26,6 +27,12 @@ export default function DeckManagerPage() {
   useEffect(() => { refresh() }, [])
   const startNew = () => setEdit({ id: crypto.randomUUID(), title: '', lang: 'en-US', lines: [], tags: [] })
   const handleFile = async (f: File) => { await importDeck(await f.text()); refresh() }
+  const handleFolder = async (list: FileList) => {
+    const { imported, fails } = await importDeckFiles(list)
+    refresh()
+    alert(`Imported ${imported} decks${fails.length ? `, ${fails.length} skipped` : ''}`)
+    if (fails.length) alert(fails.join('\n'))
+  }
   const download = (d: Deck) => {
     const slug = d.title.toLowerCase().replace(/[^a-z0-9]+/g,'-').replace(/^-|-$/g,'')
     const url = URL.createObjectURL(new Blob([exportDeck(d)], { type: 'application/json' }))
@@ -42,6 +49,9 @@ export default function DeckManagerPage() {
           <button className="border px-2" onClick={startNew}>+ New Deck</button>
           <label className="border px-2 cursor-pointer">
             Import JSON<input type="file" accept="application/json" className="hidden" onChange={e=>e.target.files&&handleFile(e.target.files[0])}/>
+          </label>
+          <label className="border px-2 cursor-pointer">
+            Import folder<input type="file" accept=".json" webkitdirectory multiple className="hidden" onChange={e=>e.target.files&&handleFolder(e.target.files)}/>
           </label>
           <button className="border px-2" onClick={() => setPaste(true)}>Import ⌘V</button>
         </span>

--- a/apps/sober-body/src/features/games/__tests__/folder-import.test.ts
+++ b/apps/sober-body/src/features/games/__tests__/folder-import.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import 'fake-indexeddb/auto'
+import * as storage from '../deck-storage'
+
+async function clearDB() {
+  const dbs = await indexedDB.databases?.()
+  if (dbs) await Promise.all(dbs.map(db => indexedDB.deleteDatabase(db.name!)))
+}
+
+describe('importDeckFiles', () => {
+  beforeEach(async () => {
+    await clearDB()
+  })
+
+  it('calls saveDeck for each file', async () => {
+    const spy = vi.fn().mockResolvedValue(undefined)
+    const f1 = { name: 'a.json', text: async () => '{"id":"a","title":"A","lang":"en","lines":["x"]}' } as File
+    const f2 = { name: 'b.json', text: async () => '{"id":"b","title":"B","lang":"en","lines":["y"]}' } as File
+    await storage.importDeckFiles([f1, f2], spy)
+    expect(spy).toHaveBeenCalledTimes(2)
+  })
+})

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -37,6 +37,7 @@ Legend: **↑ = next up** · ✅ done · ⬜ open
 * ✅ **feat(games):** improve Pronunciation UI (record/next flow, verdicts)
 * ⬜ **feat(games):** Portuguese tongue-twister deck & lang switcher
 * ✅ **feat(games):** Deck Manager CRUD + import/export
+* ✅ **feat(import):** directory picker for bulk JSON deck import
 
 ## Docs & Governance
 


### PR DESCRIPTION
## Summary
- allow importing a whole directory of JSON decks
- implement `importDeckFiles` helper
- document folder import option
- track feature in BACKLOG
- add unit test for folder imports

## Testing
- `pnpm -r lint`
- `pnpm --filter sober-body test`


------
https://chatgpt.com/codex/tasks/task_e_6862f038ab84832b8e4c6a3afcef9296