### PR TITLE
reset UI on deck switch / dual filter chips

### DIFF
--- a/apps/sober-body/src/components/DeckManagerPage.tsx
+++ b/apps/sober-body/src/components/DeckManagerPage.tsx
@@ -9,6 +9,7 @@ import {
   importDeckFiles,
 } from '../features/games/deck-storage'
 import { getCategories } from '../features/games/get-categories'
+import { getLanguages } from '../features/games/get-languages'
 import type { Deck } from '../features/games/deck-types'
 import DeckModal from './DeckModal'
 import PasteDeckModal from './PasteDeckModal'
@@ -16,6 +17,7 @@ import PasteDeckModal from './PasteDeckModal'
 export default function DeckManagerPage() {
   const [decks, setDecks] = useState<Deck[]>([])
   const [selectedCat, setSelectedCat] = useState<string | null>(null)
+  const [selectedLang, setSelectedLang] = useState<string | null>(null)
   const [edit, setEdit] = useState<Deck | null>(null)
   const [paste, setPaste] = useState(false)
   const navigate = useNavigate()
@@ -40,7 +42,11 @@ export default function DeckManagerPage() {
     a.click(); URL.revokeObjectURL(url)
   }
   const cats = getCategories(decks)
-  const visible = selectedCat ? decks.filter(d => d.tags?.includes(selectedCat)) : decks
+  const langs = getLanguages(decks)
+  const visible = decks.filter(d =>
+    (!selectedCat || d.tags?.includes(selectedCat)) &&
+    (!selectedLang || d.lang === selectedLang)
+  )
   return (
     <div className="p-4 max-w-lg mx-auto">
       <h2 className="text-xl mb-4 flex justify-between">
@@ -70,6 +76,23 @@ export default function DeckManagerPage() {
             className={`px-2 py-1 rounded-full text-xs ${selectedCat===cat?'bg-sky-600 text-white':'bg-gray-200'}`}
           >
             {cat.slice(4)}
+          </button>
+        ))}
+      </div>
+      <div className="flex gap-2 overflow-x-auto mb-4">
+        <button
+          className={`px-2 py-1 rounded-full text-xs ${selectedLang===null?'bg-sky-600 text-white':'bg-gray-200'}`}
+          onClick={() => setSelectedLang(null)}
+        >
+          All
+        </button>
+        {langs.map(l => (
+          <button
+            key={l}
+            onClick={() => setSelectedLang(c => c===l?null:l)}
+            className={`px-2 py-1 rounded-full text-xs ${selectedLang===l?'bg-sky-600 text-white':'bg-gray-200'}`}
+          >
+            {l}
           </button>
         ))}
       </div>

--- a/apps/sober-body/src/components/PronunciationCoachUI.test.tsx
+++ b/apps/sober-body/src/components/PronunciationCoachUI.test.tsx
@@ -77,8 +77,8 @@ describe('PronunciationCoachUI translation', () => {
 describe('PronunciationCoachUI deck switching', () => {
   it('resets index when active deck changes', async () => {
     mockDecks.splice(0, mockDecks.length,
-      { id: 'a', title: 'A', lang: 'en', lines: ['a one', 'a two'], tags: [] },
-      { id: 'b', title: 'B', lang: 'en', lines: ['b one', 'b two'], tags: [] },
+      { id: 'a', title: 'A', lang: 'pt-BR', lines: ['a one', 'a two'], tags: [] },
+      { id: 'b', title: 'B', lang: 'fr-FR', lines: ['b one', 'b two'], tags: [] },
     )
 
     function Wrapper() {
@@ -108,6 +108,8 @@ describe('PronunciationCoachUI deck switching', () => {
     await screen.findAllByText('b one')
     const prev = screen.getByRole('button', { name: 'Prev' }) as HTMLButtonElement
     expect(prev.disabled).toBe(true)
+    const dropdown = screen.getAllByRole('combobox')[1] as HTMLSelectElement
+    expect(dropdown.value).toBe('fr-FR')
   })
 })
 

--- a/apps/sober-body/src/components/PronunciationCoachUI.tsx
+++ b/apps/sober-body/src/components/PronunciationCoachUI.tsx
@@ -67,7 +67,8 @@ export default function PronunciationCoachUI() {
 
   useEffect(() => {
     setIndex(0);
-  }, [currentDeck.id]);
+    setSettings(s => ({ ...s, locale: currentDeck.lang }))
+  }, [currentDeck.id, currentDeck.lang, setSettings]);
 
 
   const current = lines[index] ?? raw;

--- a/apps/sober-body/src/features/games/__tests__/language-filter.test.ts
+++ b/apps/sober-body/src/features/games/__tests__/language-filter.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest'
+import { getLanguages } from '../get-languages'
+import type { Deck } from '../deck-types'
+
+const decks: Deck[] = [
+  { id: '1', title: 'Taxi FR', lang: 'fr-FR', lines: ['a'], tags: ['cat:hotel'] },
+  { id: '2', title: 'Taxi EN', lang: 'en-US', lines: ['b'], tags: ['cat:hotel'] },
+  { id: '3', title: 'Taxi PT', lang: 'pt-BR', lines: ['c'], tags: ['cat:groceries'] },
+]
+
+describe('language filtering', () => {
+  it('filters by category and language', () => {
+    const langs = getLanguages(decks)
+    expect(langs).toContain('fr-FR')
+    const visible = decks.filter(d =>
+      d.tags?.includes('cat:hotel') && d.lang === 'fr-FR'
+    )
+    expect(visible.length).toBe(1)
+    expect(visible[0].title).toBe('Taxi FR')
+  })
+})

--- a/apps/sober-body/src/features/games/get-languages.ts
+++ b/apps/sober-body/src/features/games/get-languages.ts
@@ -1,0 +1,5 @@
+export function getLanguages(decks: import('./deck-types').Deck[]): string[] {
+  const set = new Set<string>()
+  decks.forEach(d => set.add(d.lang))
+  return Array.from(set).sort()
+}

--- a/packages/pronunciation-coach/src/langs.ts
+++ b/packages/pronunciation-coach/src/langs.ts
@@ -1,8 +1,8 @@
 export const LANGS = [
-  { code: 'en', label: 'English' },
+  { code: 'en-US', label: 'English' },
   { code: 'pt-BR', label: 'Português' },
-  { code: 'es', label: 'Español' },
-  { code: 'fr', label: 'Français' },
-  { code: 'de', label: 'Deutsch' }
+  { code: 'es-ES', label: 'Español' },
+  { code: 'fr-FR', label: 'Français' },
+  { code: 'de-DE', label: 'Deutsch' }
 ] as const;
 export type LangCode = typeof LANGS[number]['code'];


### PR DESCRIPTION
## Summary
- reset drill index and selected locale when changing deck
- show chip filters for languages next to categories
- expose `getLanguages` util with tests
- keep dropdown languages in regional form

## Testing
- `pnpm -r lint`
- `pnpm -r test`

------
https://chatgpt.com/codex/tasks/task_e_686316b56160832bb03c59721ebe6445