### PR TITLE
use deck.id for Play button (fix wrong deck selected)

### DIFF
--- a/apps/sober-body/src/components/DeckManagerPage.test.tsx
+++ b/apps/sober-body/src/components/DeckManagerPage.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import 'fake-indexeddb/auto'
+import DeckManagerPage from './DeckManagerPage'
+
+const mockDecks = [
+  { id: 'a', title: 'A', lang: 'pt-BR', lines: ['1'], tags: [], updated: 2 },
+  { id: 'b', title: 'B', lang: 'en', lines: ['2'], tags: [], updated: 1 },
+  { id: 'c', title: 'C', lang: 'en', lines: ['3'], tags: [], updated: 3 },
+]
+
+vi.mock('../features/games/deck-storage', () => ({
+  loadDecks: vi.fn(async () => mockDecks),
+  saveDeck: vi.fn(),
+  deleteDeck: vi.fn(),
+  exportDeck: vi.fn(),
+  importDeck: vi.fn(),
+  importDeckFiles: vi.fn(),
+}))
+
+const navigate = vi.fn()
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom')
+  return { ...actual, useNavigate: () => navigate }
+})
+
+describe('DeckManagerPage play button', () => {
+  it('navigates with deck id from visible row', async () => {
+    render(<DeckManagerPage />)
+
+    fireEvent.click(await screen.findByRole('button', { name: 'en' }))
+    const buttons = await screen.findAllByRole('button', { name: 'Start drill' })
+    fireEvent.click(buttons[1])
+    expect(navigate).toHaveBeenCalledWith('/coach?deck=b')
+  })
+})

--- a/apps/sober-body/src/components/DeckManagerPage.tsx
+++ b/apps/sober-body/src/components/DeckManagerPage.tsx
@@ -21,6 +21,9 @@ export default function DeckManagerPage() {
   const [edit, setEdit] = useState<Deck | null>(null)
   const [paste, setPaste] = useState(false)
   const navigate = useNavigate()
+  const handlePlay = (id: string) => {
+    navigate(`/coach?deck=${encodeURIComponent(id)}`)
+  }
   const refresh = async () => {
     const arr = await loadDecks()
     arr.sort((a,b)=>(b.updated??0)-(a.updated??0))
@@ -103,7 +106,7 @@ export default function DeckManagerPage() {
             className="flex items-center gap-3 border rounded px-3 py-2 hover:bg-sky-50"
           >
             <button
-              onClick={() => navigate(`/coach?deck=${deck.id}`)}
+              onClick={() => handlePlay(deck.id)}
               className="text-sky-600 text-lg"
               title="Start drill"
               aria-label="Start drill"

--- a/apps/sober-body/src/pages/coach.tsx
+++ b/apps/sober-body/src/pages/coach.tsx
@@ -6,18 +6,14 @@ import { useDecks } from '../features/games/deck-context'
 export default function CoachPage() {
   const [params] = useSearchParams()
   const requestedId = params.get('deck')
-  const { decks, setActiveDeck, activeDeck } = useDecks()
+  const { decks, setActiveDeck } = useDecks()
 
   useEffect(() => {
     if (!requestedId || !decks.length) return
-    if (requestedId !== activeDeck && decks.some(d => d.id === requestedId)) {
-      setActiveDeck(requestedId)
-    }
-  }, [requestedId, decks, activeDeck, setActiveDeck])
-
-  if (requestedId && decks.length && !decks.some(d => d.id === requestedId)) {
-    console.warn('Deck ID from URL not found; using default.')
-  }
+    const found = decks.find(d => d.id === requestedId)
+    if (found) setActiveDeck(found.id)
+    else console.warn('Deck id not found:', requestedId)
+  }, [requestedId, decks, setActiveDeck])
 
   return <PronunciationCoachUI />
 }


### PR DESCRIPTION
## Summary
- use dedicated `handlePlay` helper and pass deck.id to it
- guard the coach route with fallback if deck id isn't found
- add a regression test clicking 2nd row after filtering

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_686351578030832b9e8a4f7644439560