### PR TITLE
feat(decks): category & language dropdown filters replace chip bar

### DIFF
--- a/apps/sober-body/src/components/DeckManagerPage.test.tsx
+++ b/apps/sober-body/src/components/DeckManagerPage.test.tsx
@@ -1,12 +1,13 @@
-import { render, screen, fireEvent } from '@testing-library/react'
-import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent, cleanup } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, it, expect, vi, afterEach } from 'vitest'
 import 'fake-indexeddb/auto'
 import DeckManagerPage from './DeckManagerPage'
 
 const mockDecks = [
-  { id: 'a', title: 'A', lang: 'pt-BR', lines: ['1'], tags: [], updated: 2 },
-  { id: 'b', title: 'B', lang: 'en', lines: ['2'], tags: [], updated: 1 },
-  { id: 'c', title: 'C', lang: 'en', lines: ['3'], tags: [], updated: 3 },
+  { id: 'a', title: 'A', lang: 'pt-BR', lines: ['1'], tags: ['cat:hotel'], updated: 2 },
+  { id: 'b', title: 'B', lang: 'en', lines: ['2'], tags: ['cat:groceries'], updated: 1 },
+  { id: 'c', title: 'C', lang: 'en', lines: ['3'], tags: ['cat:hotel'], updated: 3 },
 ]
 
 vi.mock('../features/games/deck-storage', () => ({
@@ -24,13 +25,43 @@ vi.mock('react-router-dom', async () => {
   return { ...actual, useNavigate: () => navigate }
 })
 
+afterEach(() => cleanup())
+
 describe('DeckManagerPage play button', () => {
   it('navigates with deck id from visible row', async () => {
+    const user = userEvent.setup()
     render(<DeckManagerPage />)
 
-    fireEvent.click(await screen.findByRole('button', { name: 'en' }))
+    await user.selectOptions(await screen.findByLabelText(/language/i, { selector: 'select' }), 'en')
     const buttons = await screen.findAllByRole('button', { name: 'Start drill' })
     fireEvent.click(buttons[1])
     expect(navigate).toHaveBeenCalledWith('/coach?deck=b')
+  })
+})
+
+describe('DeckManagerPage filters', () => {
+  it('category + language filter reduces visible decks', async () => {
+    const user = userEvent.setup()
+    render(<DeckManagerPage />)
+
+    await user.selectOptions(await screen.findByLabelText(/language/i, { selector: 'select' }), 'pt-BR')
+    await user.selectOptions(screen.getByLabelText(/categories/i, { selector: 'select' }), 'hotel')
+
+    const rows = await screen.findAllByRole('listitem')
+    expect(rows).toHaveLength(1)
+    expect(rows[0].textContent).toContain('A')
+  })
+
+  it('clearing filters shows all decks', async () => {
+    const user = userEvent.setup()
+    render(<DeckManagerPage />)
+
+    await user.selectOptions(await screen.findByLabelText(/language/i, { selector: 'select' }), 'pt-BR')
+    await user.selectOptions(screen.getByLabelText(/categories/i, { selector: 'select' }), 'hotel')
+    await user.deselectOptions(screen.getByLabelText(/categories/i, { selector: 'select' }), 'hotel')
+    await user.selectOptions(screen.getByLabelText(/language/i, { selector: 'select' }), 'all')
+
+    const rows = await screen.findAllByRole('listitem')
+    expect(rows).toHaveLength(3)
   })
 })

--- a/package.json
+++ b/package.json
@@ -6,5 +6,8 @@
     "dev:coach": "pnpm --filter packages/pronunciation-coach dev",
     "dev:all": "pnpm -r dev",
     "test": "pnpm -r --parallel test"
+  },
+  "devDependencies": {
+    "@testing-library/user-event": "^14.6.1"
   }
 }


### PR DESCRIPTION
## Summary
- replace chip filter bar with new dropdown filters on Deck Manager page
- persist selected categories and language in localStorage
- show option counts in category dropdown
- add tests for dropdown filtering logic
- add `@testing-library/user-event` for testing multi-select

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_686592b67f9c832b811347648d2c6adf