### PR TITLE
refine phrase splitter to prevent multi-sentence phrases

### DIFF
--- a/apps/sober-body/src/features/games/parser.ts
+++ b/apps/sober-body/src/features/games/parser.ts
@@ -11,11 +11,18 @@ export function splitUnits(text: string, mode: SplitMode): string[] {
         .map(l => l.trim())
         .filter(Boolean);
     case 'phrase': {
-      const parts = trimmed
-        .split(/[;,—–]/)
-        .map(t => t.trim())
+      const sentences = trimmed
+        .replace(/\r?\n/g, ' ')
+        .split(/[.!?](?:\s+|$)/)
+        .map(s => s.trim())
         .filter(Boolean);
-      return parts.length > 1 ? parts : splitUnits(trimmed, 'sentence');
+      const phrases = sentences.flatMap(sent =>
+        sent
+          .split(/[;,—–]/)
+          .map(p => p.trim())
+          .filter(Boolean)
+      );
+      return phrases.length > 1 ? phrases : sentences;
     }
     case 'sentence':
       return trimmed

--- a/apps/sober-body/test/parser.test.ts
+++ b/apps/sober-body/test/parser.test.ts
@@ -7,7 +7,12 @@ describe('splitUnits', () => {
   })
 
   it('falls back to sentence when no commas', () => {
-    expect(splitUnits('Hello world.', 'phrase')).toEqual(['Hello world.'])
+    expect(splitUnits('Hello world.', 'phrase')).toEqual(['Hello world'])
+  })
+
+  it('splits across sentences first', () => {
+    const t = 'A. B. C, D, E. F.'
+    expect(splitUnits(t, 'phrase')).toEqual(['A', 'B', 'C', 'D', 'E', 'F'])
   })
 
   it('paragraph split by blank lines', () => {


### PR DESCRIPTION
## Summary
- refine `splitUnits` phrase mode: split sentences first, then phrases
- update parser tests for new phrase logic

## Testing
- `pnpm -r lint`
- `pnpm -r test`

------
https://chatgpt.com/codex/tasks/task_e_6865b7ca63b8832b9fe095a48e742168