### PR TITLE
feat(grammar): loader & modal for deck-specific grammar briefs

### DIFF
--- a/apps/sober-body/src/components/GrammarModal.test.tsx
+++ b/apps/sober-body/src/components/GrammarModal.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen, cleanup } from '@testing-library/react'
+import { describe, it, expect, afterEach } from 'vitest'
+import GrammarModal from './GrammarModal'
+import type { BriefWithRefs } from '../grammar-loader'
+
+const brief: BriefWithRefs = {
+  id: 'b',
+  story: 's',
+  grammar: {},
+  notes: [],
+  linkedRefs: [
+    { id: 'a', title: 'Pretérito Perfeito', description: '', examples: [] },
+    { id: 'b', title: "Futuro com 'ir'", description: '', examples: [] },
+    { id: 'c', title: 'Preposição "para"', description: '', examples: [] },
+  ],
+}
+
+describe('GrammarModal', () => {
+  afterEach(() => cleanup())
+  it('renders ref titles', () => {
+    render(<GrammarModal open brief={brief} onClose={() => {}} />)
+    expect(screen.getByText('Pretérito Perfeito')).toBeTruthy()
+    expect(screen.getByText("Futuro com 'ir'")).toBeTruthy()
+    expect(screen.getByText('Preposição "para"')).toBeTruthy()
+  })
+})

--- a/apps/sober-body/src/components/GrammarModal.tsx
+++ b/apps/sober-body/src/components/GrammarModal.tsx
@@ -1,0 +1,47 @@
+import React from 'react'
+import type { BriefWithRefs } from '../grammar-loader'
+
+export default function GrammarModal({
+  open,
+  brief,
+  onClose,
+}: {
+  open: boolean
+  brief: BriefWithRefs
+  onClose: () => void
+}) {
+  if (!open) return null
+  return (
+    <div className="fixed inset-0 bg-black/50 flex justify-center items-center z-50">
+      <div className="bg-white rounded-md p-4 max-w-md w-full">
+        <h2 className="text-lg font-semibold mb-4">Grammar Brief – {brief.story}</h2>
+        {brief.notes && (
+          <div className="mb-4">
+            <h3 className="font-semibold mb-1">Notes</h3>
+            <ul className="list-disc pl-5 text-sm">
+              {brief.notes.map((n, i) => (
+                <li key={i} dangerouslySetInnerHTML={{ __html: n }} />
+              ))}
+            </ul>
+          </div>
+        )}
+        <div className="space-y-2 max-h-64 overflow-y-auto">
+          {brief.linkedRefs.map(r => (
+            <details key={r.id} className="border px-2 py-1 rounded">
+              <summary className="cursor-pointer font-semibold">{r.title}</summary>
+              <p className="text-sm mb-1">{r.description}</p>
+              <ul className="list-disc pl-5 text-sm">
+                {r.examples.map((ex, i) => (
+                  <li key={i}>{ex}</li>
+                ))}
+              </ul>
+            </details>
+          ))}
+        </div>
+        <div className="text-right mt-4">
+          <button onClick={onClose} className="px-4 py-1 border">Close</button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/sober-body/src/components/PronunciationCoachUI.tsx
+++ b/apps/sober-body/src/components/PronunciationCoachUI.tsx
@@ -8,6 +8,9 @@ import { LANGS } from "../../../../packages/pronunciation-coach/src/langs";
 import { useSettings } from "../features/core/settings-context";
 import { useDecks } from "../features/games/deck-context";
 import type { Deck } from "../features/games/deck-types";
+import GrammarModal from "./GrammarModal";
+import { getBriefForDeck } from "../grammar-loader";
+import type { BriefWithRefs } from "../grammar-loader";
 
 const defaultDeck: Deck = {
   id: 'example',
@@ -34,6 +37,7 @@ export default function PronunciationCoachUI() {
   )
   const { settings, setSettings } = useSettings();
   const navigate = useNavigate();
+  const [brief, setBrief] = useState<BriefWithRefs | null>(null);
 
   useEffect(() => {
     localStorage.setItem('pc_translateMode', tMode)
@@ -87,6 +91,15 @@ export default function PronunciationCoachUI() {
     doTranslate(sel || current)
   }
 
+  const handleGrammar = () => {
+    const b = getBriefForDeck(currentDeck.id)
+    if (!b) {
+      alert('No grammar notes for this deck yet.')
+    } else {
+      setBrief(b)
+    }
+  }
+
   useEffect(() => {
     if (translation) speak();
   }, [translation]);
@@ -104,6 +117,7 @@ export default function PronunciationCoachUI() {
   }, []);
 
   return (
+    <>
     <div
       className="grid grid-cols-2 gap-x-28 gap-y-12 max-w-7xl mx-auto px-10 pt-10"
     >
@@ -209,6 +223,9 @@ export default function PronunciationCoachUI() {
             >
               {coach.recording ? "■ Stop" : "⏺ Record"}
             </button>
+            <button onClick={handleGrammar} className="px-3 py-1 text-lg">
+              📖 Grammar
+            </button>
             <label className="ml-2 text-sm flex items-center gap-1">Translate:
               <select
                 value={tMode}
@@ -269,6 +286,8 @@ export default function PronunciationCoachUI() {
           )}
       </section>
     </div>
+    <GrammarModal open={Boolean(brief)} brief={brief!} onClose={() => setBrief(null)} />
+    </>
   );
 }
 

--- a/apps/sober-body/src/grammar-loader.ts
+++ b/apps/sober-body/src/grammar-loader.ts
@@ -1,0 +1,43 @@
+export interface Ref {
+  id: string
+  title: string
+  description: string
+  examples: string[]
+}
+
+export interface Brief {
+  id: string
+  story: string
+  grammar: Record<string, string[]>
+  notes?: string[]
+}
+
+export interface BriefWithRefs extends Brief {
+  linkedRefs: Ref[]
+}
+
+const refFiles = import.meta.glob('/src/grammar/ref/*.json', {
+  eager: true,
+  import: 'default'
+}) as Record<string, Ref>
+export const refs: Record<string, Ref> = Object.fromEntries(
+  Object.values(refFiles).map(r => [r.id, r])
+)
+
+const briefFiles = import.meta.glob('/src/grammar/briefs/*.json', {
+  eager: true,
+  import: 'default'
+}) as Record<string, Brief>
+export const briefs: Record<string, Brief> = Object.fromEntries(
+  Object.values(briefFiles).map(b => [b.id, b])
+)
+
+export function getBriefForDeck(deckId: string): BriefWithRefs | null {
+  const brief = Object.values(briefs).find(b => b.story === deckId)
+  if (!brief) return null
+  const linkedRefs = Object.values(brief.grammar)
+    .flat()
+    .map(id => refs[id])
+    .filter(Boolean)
+  return { ...brief, linkedRefs }
+}

--- a/apps/sober-body/src/grammar/briefs/brief-visita-museu.json
+++ b/apps/sober-body/src/grammar/briefs/brief-visita-museu.json
@@ -1,0 +1,17 @@
+{
+  "id": "brief-visita-museu",
+  "story": "drill-visita-museu-pt-BR",
+  "grammar": {
+    "verb_tenses": [
+      "tense:preterito-perfeito",
+      "tense:ir-futuro"
+    ],
+    "prepositions": [
+      "prep:para"
+    ]
+  },
+  "notes": [
+    "Past actions are in **Pretérito Perfeito**.",
+    "Future is expressed with **ir + infinitive**."
+  ]
+}

--- a/apps/sober-body/src/grammar/ref/prep-para.json
+++ b/apps/sober-body/src/grammar/ref/prep-para.json
@@ -1,0 +1,9 @@
+{
+  "id": "prep:para",
+  "title": "Preposição \"para\"",
+  "description": "Indicates destination or purpose.",
+  "examples": [
+    "Vamos para o museu.",
+    "Estou estudando para a prova."
+  ]
+}

--- a/apps/sober-body/src/grammar/ref/tense-ir-futuro.json
+++ b/apps/sober-body/src/grammar/ref/tense-ir-futuro.json
@@ -1,0 +1,9 @@
+{
+  "id": "tense:ir-futuro",
+  "title": "Futuro com 'ir'",
+  "description": "Formed with ir + infinitive to express near future.",
+  "examples": [
+    "Eu vou estudar amanhã.",
+    "Eles vão viajar."
+  ]
+}

--- a/apps/sober-body/src/grammar/ref/tense-preterito-perfeito.json
+++ b/apps/sober-body/src/grammar/ref/tense-preterito-perfeito.json
@@ -1,0 +1,9 @@
+{
+  "id": "tense:preterito-perfeito",
+  "title": "Pretérito Perfeito",
+  "description": "Used for completed past actions.",
+  "examples": [
+    "Ontem eu estudei muito.",
+    "Ela foi ao mercado."
+  ]
+}

--- a/apps/sober-body/test/grammar-loader.test.ts
+++ b/apps/sober-body/test/grammar-loader.test.ts
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest'
+import { getBriefForDeck } from '../src/grammar-loader'
+
+describe('getBriefForDeck', () => {
+  it('links refs for deck', () => {
+    const brief = getBriefForDeck('drill-visita-museu-pt-BR')
+    expect(brief?.linkedRefs).toHaveLength(3)
+  })
+})


### PR DESCRIPTION
## Summary
- add reference & brief JSON samples
- implement grammar-loader with getBriefForDeck
- show GrammarModal from PronunciationCoachUI
- add tests for loader & modal

## Testing
- `pnpm -r test`
- `pnpm -r lint`

------
https://chatgpt.com/codex/tasks/task_e_6865be097c1c832bac31e476226633e9