### PR TITLE
central DrillLink + deck route

### DIFF
--- a/apps/sober-body/src/App.tsx
+++ b/apps/sober-body/src/App.tsx
@@ -5,6 +5,7 @@ import { seedPresetDecks } from './features/games/deck-storage'
 import BacDashboard from './components/BacDashboard'
 import LandingPage from './components/LandingPage'
 import CoachPage from './pages/coach'
+import CoachLegacy from './pages/coach-legacy'
 import DecksPage from './pages/decks'
 import { DrinkLogProvider } from './features/core/drink-context'
 import { SettingsProvider } from './features/core/settings-context'
@@ -19,7 +20,8 @@ function App() {
         <Routes>
           <Route path="/" element={<LandingPage />} />
           <Route path="/app" element={<BacDashboard />} />
-          <Route path="/coach" element={<CoachPage />} />
+          <Route path="/coach/deck/:id" element={<CoachPage />} />
+          <Route path="/coach" element={<CoachLegacy />} />
           <Route path="/decks" element={<DecksPage />} />
         </Routes>
       </DrinkLogProvider>

--- a/apps/sober-body/src/components/BriefDrawer.tsx
+++ b/apps/sober-body/src/components/BriefDrawer.tsx
@@ -52,14 +52,14 @@ export default function BriefDrawer({ deck, onClose }: { deck: Deck; onClose: ()
           isMulti
           options={tenseOpts}
           value={tenseOpts.filter(o => verbTenses.includes(o.value))}
-          onChange={vals => setVerbTenses(vals.map(v => (v as any).value))}
+          onChange={vals => setVerbTenses(vals.map(v => (v as { value: string }).value))}
         />
         <div className="mb-2 mt-4 text-sm">Prepositions</div>
         <Select
           isMulti
           options={prepOpts}
           value={prepOpts.filter(o => preps.includes(o.value))}
-          onChange={vals => setPreps(vals.map(v => (v as any).value))}
+          onChange={vals => setPreps(vals.map(v => (v as { value: string }).value))}
         />
         <div className="mt-4">
           <textarea

--- a/apps/sober-body/src/components/DeckManagerPage.test.tsx
+++ b/apps/sober-body/src/components/DeckManagerPage.test.tsx
@@ -1,4 +1,5 @@
-import { render, screen, fireEvent, cleanup } from '@testing-library/react'
+import { render, screen, cleanup } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
 import userEvent from '@testing-library/user-event'
 import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest'
 import 'fake-indexeddb/auto'
@@ -19,11 +20,6 @@ vi.mock('../features/games/deck-storage', () => ({
   importDeckFiles: vi.fn(),
 }))
 
-const navigate = vi.fn()
-vi.mock('react-router-dom', async () => {
-  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom')
-  return { ...actual, useNavigate: () => navigate }
-})
 
 beforeEach(() => {
   localStorage.clear()
@@ -33,29 +29,39 @@ afterEach(() => cleanup())
 describe('DeckManagerPage play button', () => {
   it('navigates with deck id from visible row', async () => {
     const user = userEvent.setup()
-    render(<DeckManagerPage />)
+    render(
+      <MemoryRouter>
+        <DeckManagerPage />
+      </MemoryRouter>
+    )
 
     await screen.findByRole('option', { name: 'en' })
     await user.selectOptions(await screen.findByLabelText(/language/i, { selector: 'select' }), 'en')
-    const buttons = await screen.findAllByRole('button', { name: 'Start drill' })
-    fireEvent.click(buttons[1])
-    expect(navigate).toHaveBeenCalledWith('/coach?deck=b')
+    const links = await screen.findAllByRole('link', { name: 'Start drill' })
+    expect(links[1].getAttribute('href')).toBe('/coach/deck/b')
   })
 
   it('navigates with deck id from third row', async () => {
-    render(<DeckManagerPage />)
+    render(
+      <MemoryRouter>
+        <DeckManagerPage />
+      </MemoryRouter>
+    )
 
-    const buttons = await screen.findAllByRole('button', { name: 'Start drill' })
-    expect(buttons).toHaveLength(3)
-    fireEvent.click(buttons[2])
-    expect(navigate).toHaveBeenCalledWith('/coach?deck=b')
+    const links = await screen.findAllByRole('link', { name: 'Start drill' })
+    expect(links).toHaveLength(3)
+    expect(links[2].getAttribute('href')).toBe('/coach/deck/b')
   })
 })
 
 describe('DeckManagerPage filters', () => {
   it('category + language filter reduces visible decks', async () => {
     const user = userEvent.setup()
-    render(<DeckManagerPage />)
+    render(
+      <MemoryRouter>
+        <DeckManagerPage />
+      </MemoryRouter>
+    )
 
     await screen.findByRole('option', { name: 'pt-BR' })
     await user.selectOptions(await screen.findByLabelText(/language/i, { selector: 'select' }), 'pt-BR')
@@ -68,7 +74,11 @@ describe('DeckManagerPage filters', () => {
 
   it('clearing filters shows all decks', async () => {
     const user = userEvent.setup()
-    render(<DeckManagerPage />)
+    render(
+      <MemoryRouter>
+        <DeckManagerPage />
+      </MemoryRouter>
+    )
 
     await screen.findByRole('option', { name: 'pt-BR' })
     await user.selectOptions(await screen.findByLabelText(/language/i, { selector: 'select' }), 'pt-BR')

--- a/apps/sober-body/src/components/DeckManagerPage.tsx
+++ b/apps/sober-body/src/components/DeckManagerPage.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useState } from 'react'
-import { useNavigate } from 'react-router-dom'
 import {
   loadDecks,
   saveDeck,
@@ -14,6 +13,7 @@ import type { Deck } from '../features/games/deck-types'
 import DeckModal from './DeckModal'
 import PasteDeckModal from './PasteDeckModal'
 import BriefDrawer from './BriefDrawer'
+import DrillLink from './DrillLink'
 
 export default function DeckManagerPage() {
   const [decks, setDecks] = useState<Deck[]>([])
@@ -31,10 +31,6 @@ export default function DeckManagerPage() {
   const [edit, setEdit] = useState<Deck | null>(null)
   const [paste, setPaste] = useState(false)
   const [briefDeck, setBriefDeck] = useState<Deck | null>(null)
-  const navigate = useNavigate()
-  const handlePlay = (id: string) => {
-    navigate(`/coach?deck=${encodeURIComponent(id)}`)
-  }
   const refresh = async () => {
     const arr = await loadDecks()
     arr.sort((a,b)=>(b.updated??0)-(a.updated??0))
@@ -130,14 +126,7 @@ export default function DeckManagerPage() {
             key={deck.id}
             className="flex items-center gap-3 border rounded px-3 py-2 hover:bg-sky-50 group"
           >
-            <button
-              onClick={() => handlePlay(deck.id)}
-              className="text-sky-600 text-lg"
-              title="Start drill"
-              aria-label="Start drill"
-            >
-              ▶
-            </button>
+            <DrillLink deck={deck} />
             <div className="flex-1">
               <div className="font-medium">{deck.title}</div>
               <div className="text-xs text-gray-500">

--- a/apps/sober-body/src/components/DrillLink.test.tsx
+++ b/apps/sober-body/src/components/DrillLink.test.tsx
@@ -1,0 +1,18 @@
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, it, expect } from 'vitest'
+import DrillLink from './DrillLink'
+
+const deck = { id: 'x', title: 'X', lang: 'en', lines: [], tags: [] as string[] }
+
+describe('DrillLink', () => {
+  it('links to deck path', () => {
+    render(
+      <MemoryRouter>
+        <DrillLink deck={deck} />
+      </MemoryRouter>
+    )
+    const link = screen.getByRole('link', { name: 'Start drill' })
+    expect(link.getAttribute('href')).toBe('/coach/deck/x')
+  })
+})

--- a/apps/sober-body/src/components/DrillLink.tsx
+++ b/apps/sober-body/src/components/DrillLink.tsx
@@ -1,0 +1,15 @@
+import { Link } from 'react-router-dom'
+import type { Deck } from '../features/games/deck-types'
+
+export default function DrillLink({ deck }: { deck: Deck }) {
+  return (
+    <Link
+      to={`/coach/deck/${encodeURIComponent(deck.id)}`}
+      title={`Drill "${deck.title}"`}
+      aria-label="Start drill"
+      className="text-sky-600 text-lg"
+    >
+      ▶
+    </Link>
+  )
+}

--- a/apps/sober-body/src/features/games/deck-context.tsx
+++ b/apps/sober-body/src/features/games/deck-context.tsx
@@ -35,3 +35,8 @@ export function useDecks() {
   if (!ctx) throw new Error('useDecks must be used within DeckProvider')
   return ctx
 }
+
+export function useDeck(id: string) {
+  const { decks } = useDecks()
+  return decks.find(d => d.id === id)
+}

--- a/apps/sober-body/src/pages/__tests__/coach.test.tsx
+++ b/apps/sober-body/src/pages/__tests__/coach.test.tsx
@@ -21,13 +21,13 @@ function ActiveDisplay() {
 }
 
 describe('CoachPage routing', () => {
-  it('sets active deck from query param', async () => {
+  it('loads deck from param path', async () => {
     render(
-      <MemoryRouter initialEntries={['/coach?deck=abc']}>
+      <MemoryRouter initialEntries={['/coach/deck/abc']}>
         <SettingsProvider>
           <DeckProvider>
             <Routes>
-              <Route path="/coach" element={<><CoachPage /><ActiveDisplay /></>} />
+              <Route path="/coach/deck/:id" element={<><CoachPage /><ActiveDisplay /></>} />
             </Routes>
           </DeckProvider>
         </SettingsProvider>
@@ -38,14 +38,14 @@ describe('CoachPage routing', () => {
     })
   })
 
-  it('loads deck from URL once decks are ready', async () => {
+  it('skips warning once decks are ready', async () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
     render(
-      <MemoryRouter initialEntries={['/coach?deck=abc']}>
+      <MemoryRouter initialEntries={['/coach/deck/abc']}>
         <SettingsProvider>
           <DeckProvider>
             <Routes>
-              <Route path="/coach" element={<><CoachPage /><ActiveDisplay /></>} />
+              <Route path="/coach/deck/:id" element={<><CoachPage /><ActiveDisplay /></>} />
             </Routes>
           </DeckProvider>
         </SettingsProvider>

--- a/apps/sober-body/src/pages/coach-legacy.tsx
+++ b/apps/sober-body/src/pages/coach-legacy.tsx
@@ -1,0 +1,8 @@
+import { useSearchParams, Navigate } from 'react-router-dom'
+
+export default function CoachLegacy() {
+  const [params] = useSearchParams()
+  const id = params.get('deck')
+  if (id) return <Navigate to={`/coach/deck/${encodeURIComponent(id)}`} replace />
+  return <Navigate to="/decks" replace />
+}

--- a/apps/sober-body/src/pages/coach.tsx
+++ b/apps/sober-body/src/pages/coach.tsx
@@ -1,19 +1,18 @@
 import { useEffect } from 'react'
-import { useSearchParams } from 'react-router-dom'
+import { useParams, Navigate } from 'react-router-dom'
 import PronunciationCoachUI from '../components/PronunciationCoachUI'
-import { useDecks } from '../features/games/deck-context'
+import { useDeck, useDecks } from '../features/games/deck-context'
 
 export default function CoachPage() {
-  const [params] = useSearchParams()
-  const requestedId = params.get('deck')
+  const { id = '' } = useParams<{ id: string }>()
   const { decks, setActiveDeck } = useDecks()
+  const deck = useDeck(id)
 
   useEffect(() => {
-    if (!requestedId || !decks.length) return
-    const found = decks.find(d => d.id === requestedId)
-    if (found) setActiveDeck(found.id)
-    else console.warn('Deck id not found:', requestedId)
-  }, [requestedId, decks, setActiveDeck])
+    if (deck) setActiveDeck(deck.id)
+  }, [deck, setActiveDeck])
+
+  if (decks.length > 0 && !deck) return <Navigate to="/decks" replace />
 
   return <PronunciationCoachUI />
 }


### PR DESCRIPTION
## Summary
- add `DrillLink` component to reuse play buttons
- route `/coach/deck/:id` with legacy redirect
- load coach deck from path param
- expose `useDeck` helper
- update deck manager to use `DrillLink`
- adjust unit tests for new routing

## Testing
- `pnpm -r lint`
- `pnpm -r test`

------
https://chatgpt.com/codex/tasks/task_e_6865d438fb28832ba58d7d9eb36d26ec