### PR TITLE
feat(export): add zip utils and challenge helpers

### DIFF
--- a/apps/sober-body/package.json
+++ b/apps/sober-body/package.json
@@ -17,7 +17,8 @@
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router-dom": "^6.30.1",
-    "react-select": "^5.10.1"
+    "react-select": "^5.10.1",
+    "jszip": "^3.10.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",

--- a/apps/sober-body/src/features/games/challenge.ts
+++ b/apps/sober-body/src/features/games/challenge.ts
@@ -1,0 +1,14 @@
+export interface ChallengeData {
+  deckId: string
+  unit: number
+  text: string
+  ownerScore: number
+}
+
+export function encodeChallenge(data: ChallengeData): string {
+  return btoa(JSON.stringify(data))
+}
+
+export function decodeChallenge(payload: string): ChallengeData {
+  return JSON.parse(atob(payload))
+}

--- a/apps/sober-body/src/features/games/zip-utils.ts
+++ b/apps/sober-body/src/features/games/zip-utils.ts
@@ -1,0 +1,36 @@
+import JSZip from 'jszip'
+import type { Deck } from './deck-types'
+import type { BriefDoc } from '../../brief-storage'
+
+export async function exportZip(decks: Deck[], briefs: BriefDoc[]): Promise<Blob> {
+  const zip = new JSZip()
+  decks.forEach(d => zip.file(`decks/${d.id}.json`, JSON.stringify(d)))
+  briefs.forEach(b => zip.file(`briefs/${b.deckId}.json`, JSON.stringify(b)))
+  zip.file(
+    'manifest.json',
+    JSON.stringify({
+      exportedAt: Date.now(),
+      appVersion: '0.9',
+      decks: decks.map(d => d.id),
+    })
+  )
+  return zip.generateAsync({ type: 'blob' })
+}
+
+export async function importZip(
+  blob: Blob
+): Promise<{ decks: Deck[]; briefs: BriefDoc[] }> {
+  const zip = await JSZip.loadAsync(blob)
+  const decks: Deck[] = []
+  const briefs: BriefDoc[] = []
+  await Promise.all(
+    Object.entries(zip.files).map(async ([name, file]) => {
+      if (name.startsWith('decks/') && name.endsWith('.json')) {
+        decks.push(JSON.parse(await file.async('string')))
+      } else if (name.startsWith('briefs/') && name.endsWith('.json')) {
+        briefs.push(JSON.parse(await file.async('string')))
+      }
+    })
+  )
+  return { decks, briefs }
+}

--- a/apps/sober-body/test/challenge.test.ts
+++ b/apps/sober-body/test/challenge.test.ts
@@ -1,0 +1,11 @@
+import { describe, it, expect } from 'vitest'
+import { encodeChallenge, decodeChallenge } from '../src/features/games/challenge'
+
+describe('challenge encode/decode', () => {
+  it('round trips object', () => {
+    const obj = { deckId: 'd', unit: 2, text: 'hi', ownerScore: 90 }
+    const p = encodeChallenge(obj)
+    const res = decodeChallenge(p)
+    expect(res).toEqual(obj)
+  })
+})

--- a/apps/sober-body/test/zip-utils.test.ts
+++ b/apps/sober-body/test/zip-utils.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest'
+import { exportZip, importZip } from '../src/features/games/zip-utils'
+import type { Deck } from '../src/features/games/deck-types'
+import type { BriefDoc } from '../src/brief-storage'
+
+describe('zip utils', () => {
+  it('export and re-import decks and briefs', async () => {
+    const decks: Deck[] = [{ id: 'x', title: 'X', lang: 'en', lines: ['a'], tags: [] }]
+    const briefs: BriefDoc[] = [{ deckId: 'x', grammar: { verb_tenses: [], prepositions: [] }, notes: 'n', updatedAt: 0 }]
+    const blob = await exportZip(decks, briefs)
+    const res = await importZip(blob)
+    expect(res.decks[0].id).toBe('x')
+    expect(res.briefs[0].deckId).toBe('x')
+  })
+})


### PR DESCRIPTION
## Summary
- add jszip dependency
- implement `exportZip`/`importZip`
- scaffold challenge encode/decode utilities
- test new utilities

## Testing
- `pnpm -r lint`
- `pnpm -r test`


------
https://chatgpt.com/codex/tasks/task_e_6865de911b30832b91df1aee814628ed