### PR TITLE
feat(ui): toolbar with ZIP import/export and challenge links

### DIFF
--- a/apps/sober-body/src/App.tsx
+++ b/apps/sober-body/src/App.tsx
@@ -7,6 +7,7 @@ import LandingPage from './components/LandingPage'
 import CoachPage from './pages/coach'
 import CoachLegacy from './pages/coach-legacy'
 import DecksPage from './pages/decks'
+import ChallengePage from './pages/challenge'
 import { DrinkLogProvider } from './features/core/drink-context'
 import { SettingsProvider } from './features/core/settings-context'
 
@@ -23,6 +24,7 @@ function App() {
           <Route path="/coach/deck/:id" element={<CoachPage />} />
           <Route path="/coach" element={<CoachLegacy />} />
           <Route path="/decks" element={<DecksPage />} />
+          <Route path="/challenge/:payload" element={<ChallengePage />} />
         </Routes>
       </DrinkLogProvider>
     </SettingsProvider>

--- a/apps/sober-body/src/components/ChallengeLink.tsx
+++ b/apps/sober-body/src/components/ChallengeLink.tsx
@@ -1,0 +1,25 @@
+import { encodeChallenge } from '../features/games/challenge'
+import type { Deck } from '../features/games/deck-types'
+
+export default function ChallengeLink({ deck }: { deck: Deck }) {
+  const handle = async () => {
+    const data = { deckId: deck.id, unit: 0, text: deck.lines[0] ?? '', ownerScore: 0 }
+    const url = `${location.origin}/challenge/${encodeChallenge(data)}`
+    try {
+      await navigator.clipboard.writeText(url)
+      alert('Challenge URL copied')
+    } catch {
+      /* ignore */
+    }
+  }
+  return (
+    <button
+      aria-label="Challenge deck"
+      title="Challenge deck"
+      onClick={handle}
+      className="text-xs"
+    >
+      ⚔
+    </button>
+  )
+}

--- a/apps/sober-body/src/components/DeckManagerPage.tsx
+++ b/apps/sober-body/src/components/DeckManagerPage.tsx
@@ -14,6 +14,8 @@ import DeckModal from './DeckModal'
 import PasteDeckModal from './PasteDeckModal'
 import BriefDrawer from './BriefDrawer'
 import DrillLink from './DrillLink'
+import DeckToolbar from './DeckToolbar'
+import ChallengeLink from './ChallengeLink'
 
 export default function DeckManagerPage() {
   const [decks, setDecks] = useState<Deck[]>([])
@@ -73,16 +75,14 @@ export default function DeckManagerPage() {
     <div className="p-4 max-w-lg mx-auto">
       <h2 className="text-xl mb-4 flex justify-between">
         <span>My Decks</span>
-        <span className="space-x-2">
-          <button className="border px-2" onClick={startNew}>+ New Deck</button>
-          <label className="border px-2 cursor-pointer">
-            Import JSON<input type="file" accept="application/json" className="hidden" onChange={e=>e.target.files&&handleFile(e.target.files[0])}/>
-          </label>
-          <label className="border px-2 cursor-pointer">
-            Import folder<input type="file" accept=".json" webkitdirectory multiple className="hidden" onChange={e=>e.target.files&&handleFolder(e.target.files)}/>
-          </label>
-          <button className="border px-2" onClick={() => setPaste(true)}>Import ⌘V</button>
-        </span>
+        <DeckToolbar
+          decks={decks}
+          refresh={refresh}
+          onNew={startNew}
+          onPaste={() => setPaste(true)}
+          onFile={handleFile}
+          onFolder={handleFolder}
+        />
       </h2>
       <div className="mb-4 space-y-2">
         <label className="block text-sm">
@@ -159,6 +159,7 @@ export default function DeckManagerPage() {
             >
               ⇩
             </button>
+            <ChallengeLink deck={deck} />
             {!deck.sig && (
               <button
                 title="Delete"

--- a/apps/sober-body/src/components/DeckToolbar.tsx
+++ b/apps/sober-body/src/components/DeckToolbar.tsx
@@ -1,0 +1,87 @@
+import { useRef } from 'react'
+import type { Deck } from '../features/games/deck-types'
+import { exportZip, importZip } from '../features/games/zip-utils'
+import { saveDeck } from '../features/games/deck-storage'
+import { saveBrief, loadBrief, type BriefDoc } from '../brief-storage'
+
+export default function DeckToolbar({
+  decks,
+  refresh,
+  onNew,
+  onPaste,
+  onFile,
+  onFolder,
+}: {
+  decks: Deck[]
+  refresh: () => void
+  onNew: () => void
+  onPaste: () => void
+  onFile: (file: File) => void
+  onFolder: (files: FileList) => void
+}) {
+  const zipRef = useRef<HTMLInputElement>(null)
+  const handleZipImport = async (file: File) => {
+    const { decks: ds, briefs } = await importZip(file)
+    for (const d of ds) await saveDeck(d)
+    for (const b of briefs) await saveBrief(b)
+    refresh()
+  }
+  const handleZipExport = async () => {
+    const briefs: BriefDoc[] = []
+    for (const d of decks) {
+      const b = await loadBrief(d.id)
+      if (b) briefs.push(b)
+    }
+    const blob = await exportZip(decks, briefs)
+    const url = URL.createObjectURL(blob)
+    const a = Object.assign(document.createElement('a'), {
+      href: url,
+      download: 'decks.zip',
+    })
+    a.click()
+    URL.revokeObjectURL(url)
+  }
+  return (
+    <div className="space-x-2">
+      <button className="border px-2" onClick={onNew}>
+        + New Deck
+      </button>
+      <label className="border px-2 cursor-pointer">
+        Import JSON
+        <input
+          type="file"
+          accept="application/json"
+          className="hidden"
+          onChange={e => e.target.files && onFile(e.target.files[0])}
+        />
+      </label>
+      <label className="border px-2 cursor-pointer">
+        Import folder
+        <input
+          type="file"
+          accept=".json"
+          webkitdirectory=""
+          multiple
+          className="hidden"
+          onChange={e => e.target.files && onFolder(e.target.files)}
+        />
+      </label>
+      <label className="border px-2 cursor-pointer">
+        Import ZIP
+        <input
+          ref={zipRef}
+          type="file"
+          accept="application/zip"
+          className="hidden"
+          onChange={e => e.target.files && handleZipImport(e.target.files[0])}
+        />
+      </label>
+      <button className="border px-2" onClick={onPaste}>
+        Import ⌘V
+      </button>
+      <button className="border px-2" onClick={handleZipExport}>
+        Export ZIP
+      </button>
+    </div>
+  )
+}

--- a/apps/sober-body/src/pages/__tests__/challenge.test.tsx
+++ b/apps/sober-body/src/pages/__tests__/challenge.test.tsx
@@ -1,0 +1,20 @@
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import { describe, it, expect } from 'vitest'
+import ChallengePage from '../challenge'
+import { encodeChallenge } from '../../features/games/challenge'
+
+describe('ChallengePage', () => {
+  it('shows decoded text', () => {
+    const p = encodeChallenge({ deckId: 'd', unit: 1, text: 'hello', ownerScore: 0 })
+    render(
+      <MemoryRouter initialEntries={[`/challenge/${p}`]}>
+        <Routes>
+          <Route path="/challenge/:payload" element={<ChallengePage />} />
+        </Routes>
+      </MemoryRouter>
+    )
+    const node = screen.getByText('hello')
+    expect(node.textContent).toBe('hello')
+  })
+})

--- a/apps/sober-body/src/pages/challenge.tsx
+++ b/apps/sober-body/src/pages/challenge.tsx
@@ -1,0 +1,16 @@
+import { useParams, Link } from 'react-router-dom'
+import { decodeChallenge } from '../features/games/challenge'
+
+export default function ChallengePage() {
+  const { payload = '' } = useParams<{ payload: string }>()
+  const data = decodeChallenge(payload)
+  return (
+    <div className="p-4">
+      <h2 className="text-lg mb-2">Challenge</h2>
+      <p>{data.text}</p>
+      <Link to={`/coach/deck/${encodeURIComponent(data.deckId)}`} className="text-sky-600 underline">
+        Open Deck
+      </Link>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add `DeckToolbar` with ZIP export/import
- integrate toolbar into deck manager page
- add `ChallengeLink` button and new `/challenge/:payload` route
- show decoded challenge text on ChallengePage
- test ChallengePage decoding

## Testing
- `pnpm -r lint`
- `pnpm -r test`


------
https://chatgpt.com/codex/tasks/task_e_6865ece10dec832bbdc5a4fcc90c3b90