### PR TITLE
Add Dexie deck management

### DIFF
--- a/apps/sober-body/src/components/DeckManager.test.tsx
+++ b/apps/sober-body/src/components/DeckManager.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, it, expect, vi } from 'vitest'
+import DeckManager from './DeckManager'
+import * as hooks from '../../../../packages/core-speech/src/hooks/useDecks'
+
+const mockUseDecks = {
+  decks: [
+    { id: '1', name: 'A', cardCount: 2, importedAt: 0 }
+  ],
+  deleteDeck: vi.fn(),
+  clearAllDecks: vi.fn()
+}
+
+vi.spyOn(hooks, 'useDecks').mockReturnValue(mockUseDecks as any)
+
+describe('DeckManager', () => {
+  it('renders deck list', () => {
+    render(
+      <MemoryRouter>
+        <DeckManager />
+      </MemoryRouter>
+    )
+    expect(screen.getByText('A')).toBeTruthy()
+  })
+})

--- a/apps/sober-body/src/components/DeckManager.tsx
+++ b/apps/sober-body/src/components/DeckManager.tsx
@@ -1,0 +1,36 @@
+import { useDecks } from '../../../../packages/core-speech/src/hooks/useDecks'
+
+export default function DeckManager() {
+  const { decks, deleteDeck, clearAllDecks } = useDecks()
+
+  const openDeck = (id: string) => {
+    window.location.href = `/coach/deck/${id}`
+  }
+
+  return (
+    <div className="p-4 space-y-6">
+      <h2 className="text-xl font-semibold">Decks</h2>
+      <ul className="grid gap-3 md:grid-cols-2 lg:grid-cols-3">
+        {decks.map(d => (
+          <li key={d.id} className="border rounded p-2 flex justify-between">
+            <span>
+              {d.name}{' '}
+              <small className="text-gray-500">({d.cardCount})</small>
+            </span>
+            <span className="space-x-2">
+              <button onClick={() => openDeck(d.id)}>Open</button>
+              <button onClick={() => deleteDeck(d.id)} className="text-red-600">
+                Delete
+              </button>
+            </span>
+          </li>
+        ))}
+      </ul>
+      {decks.length > 0 && (
+        <button className="text-red-700" onClick={clearAllDecks}>
+          Clear all decks
+        </button>
+      )}
+    </div>
+  )
+}

--- a/apps/sober-body/src/pages/decks.tsx
+++ b/apps/sober-body/src/pages/decks.tsx
@@ -1,4 +1,4 @@
-import DeckManagerPage from '../components/DeckManagerPage'
+import DeckManager from '../components/DeckManager'
 export default function DecksPage() {
-  return <DeckManagerPage />
+  return <DeckManager />
 }

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -54,4 +54,12 @@ Legend: **↑ = next up** · ✅ done · ⬜ open
 
 ---
 
+## Sprint-3 Tasks
+
+* ⬜ **feat(storage):** Dexie schema + helpers (deckDB, CRUD) [sprint-3]
+* ⬜ **feat(core):** React hook `useDecks()` with liveQuery [sprint-3]
+* ⬜ **feat(ui):** DeckManager page + route [sprint-3]
+* ⬜ **test(core):** Vitest unit tests for CRUD [sprint-3]
+* ⬜ **test(e2e):** Cypress flow: import → delete → clear [sprint-3]
+
 *End of file*

--- a/packages/core-speech/README.md
+++ b/packages/core-speech/README.md
@@ -1,0 +1,1 @@
+# Core Speech

--- a/packages/core-speech/package.json
+++ b/packages/core-speech/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "core-speech",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "exports": {
+    "./db": "./src/db/decks.ts",
+    "./hooks": "./src/hooks/useDecks.ts"
+  },
+  "dependencies": {
+    "dexie": "^3.2.5"
+  },
+  "devDependencies": {
+    "dexie-export-import": "^4.1.0",
+    "fake-indexeddb": "^5.0.2",
+    "vitest": "^1.6.1",
+    "typescript": "~5.8.3"
+  }
+}

--- a/packages/core-speech/src/db/decks.test.ts
+++ b/packages/core-speech/src/db/decks.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import 'fake-indexeddb/auto'
+import { deckDB, deleteDeck, clearAllDecks } from './decks'
+import { exportDB, importInto } from 'dexie-export-import'
+
+async function clearDB() {
+  const dbs = await indexedDB.databases?.()
+  if (dbs) await Promise.all(dbs.map(db => indexedDB.deleteDatabase(db.name!)))
+}
+
+describe('deckDB CRUD', () => {
+  beforeEach(async () => {
+    await clearDB()
+  })
+
+  it('deleteDeck removes deck and cards', async () => {
+    await deckDB.decks.add({ id: '1', name: 'test', cardCount: 1, importedAt: 0 })
+    await deckDB.cards.add({ id: 'c1', deckId: '1', front: 'f', back: 'b' })
+    await deleteDeck('1')
+    expect(await deckDB.decks.get('1')).toBeUndefined()
+    const cards = await deckDB.cards.where('deckId').equals('1').toArray()
+    expect(cards.length).toBe(0)
+  })
+
+  it('clearAllDecks clears tables', async () => {
+    await deckDB.decks.add({ id: '1', name: 't', cardCount: 0, importedAt: 0 })
+    await deckDB.cards.add({ id: 'c1', deckId: '1', front: 'f', back: 'b' })
+    await clearAllDecks()
+    expect((await deckDB.decks.toArray()).length).toBe(0)
+    expect((await deckDB.cards.toArray()).length).toBe(0)
+  })
+
+  it('export/import roundtrip', async () => {
+    await deckDB.decks.add({ id: '1', name: 't', cardCount: 0, importedAt: 0 })
+    const blob = await exportDB(deckDB)
+    await clearDB()
+    await importInto(deckDB, blob)
+    const decks = await deckDB.decks.toArray()
+    expect(decks.length).toBe(1)
+  })
+})

--- a/packages/core-speech/src/db/decks.ts
+++ b/packages/core-speech/src/db/decks.ts
@@ -1,0 +1,63 @@
+import Dexie, { Table } from 'dexie'
+
+export interface Deck {
+  id: string
+  name: string
+  cardCount: number
+  importedAt: number
+}
+
+export interface Card {
+  id: string
+  deckId: string
+  front: string
+  back: string
+}
+
+export interface DeckSource {
+  id: string
+  deckId: string
+  fileName: string
+  fileHandle?: FileSystemFileHandle
+  lastModified: number
+}
+
+class DeckDB extends Dexie {
+  decks!: Table<Deck>
+  cards!: Table<Card>
+  sources!: Table<DeckSource>
+
+  constructor() {
+    super('soberBodyDecks')
+    this.version(1).stores({
+      decks: 'id, name, importedAt',
+      cards: 'id, deckId, front, back',
+      sources: 'id, deckId, fileName'
+    })
+  }
+}
+
+export const deckDB = new DeckDB()
+
+export async function deleteDeck(deckId: string) {
+  return deckDB.transaction('rw', deckDB.cards, deckDB.decks, async () => {
+    await deckDB.cards.where('deckId').equals(deckId).delete()
+    await deckDB.decks.delete(deckId)
+    await deckDB.sources.where('deckId').equals(deckId).delete()
+  })
+}
+
+export async function clearAllDecks() {
+  return deckDB.transaction(
+    'rw',
+    deckDB.cards,
+    deckDB.decks,
+    deckDB.sources,
+    () =>
+      Promise.all([
+        deckDB.cards.clear(),
+        deckDB.decks.clear(),
+        deckDB.sources.clear()
+      ])
+  )
+}

--- a/packages/core-speech/src/hooks/useDecks.ts
+++ b/packages/core-speech/src/hooks/useDecks.ts
@@ -1,0 +1,20 @@
+import { useState, useEffect } from 'react'
+import { liveQuery } from 'dexie'
+import { deckDB, deleteDeck, clearAllDecks, type Deck } from '../db/decks'
+
+export function useDecks() {
+  const [decks, setDecks] = useState<Deck[]>([])
+
+  useEffect(() => {
+    const sub = liveQuery(() => deckDB.decks.toArray()).subscribe({
+      next: setDecks
+    })
+    return () => sub.unsubscribe()
+  }, [])
+
+  return {
+    decks,
+    deleteDeck,
+    clearAllDecks
+  }
+}

--- a/packages/core-speech/tsconfig.app.json
+++ b/packages/core-speech/tsconfig.app.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src"],
+  "compilerOptions": {
+    "jsx": "react-jsx"
+  }
+}

--- a/packages/core-speech/tsconfig.json
+++ b/packages/core-speech/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../apps/sober-body/tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}

--- a/packages/core-speech/tsconfig.node.json
+++ b/packages/core-speech/tsconfig.node.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../apps/sober-body/tsconfig.node.json",
+  "compilerOptions": {
+    "outDir": "dist"
+  },
+  "include": ["vite.config.ts"]
+}


### PR DESCRIPTION
## Summary
- introduce new `core-speech` package with Dexie DB schema
- expose `useDecks` React hook
- add simple `<DeckManager>` component and route
- create unit tests for Dexie helpers
- document sprint-3 tasks

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6867571c8b5c832ba94896c1d50ebd8d