### PR TITLE
Fix workspace dev setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ pnpm --filter sober-body dev
 # open http://localhost:5173/app
 ```
 
+**Note:** Always run workspace scripts using `pnpm`. Using `npm run dev` will not
+link local packages like `core-storage`, leading to import errors.
+
 The Pronunciation Coach playground is in [`packages/pronunciation-coach/`](packages/pronunciation-coach/):
 
 ```bash

--- a/apps/sober-body/package.json
+++ b/apps/sober-body/package.json
@@ -11,6 +11,7 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "core-storage": "workspace:*",
     "canvas-confetti": "^1.9.3",
     "framer-motion": "^12.19.1",
     "idb-keyval": "^6.2.2",


### PR DESCRIPTION
## Summary
- add `core-storage` workspace link to the app
- document using pnpm for dev scripts to avoid missing workspace deps

## Testing
- `pnpm -r lint`
- `pnpm -r test`


------
https://chatgpt.com/codex/tasks/task_e_68675fe6cedc832bb5ae574a7e0575ad