### PR TITLE
Fix vitest root configs

### DIFF
--- a/apps/pronunco/vitest.config.ts
+++ b/apps/pronunco/vitest.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from 'vitest/config'
 import { join } from 'path'
 
 export default defineConfig({
+  root: __dirname,
   resolve: { alias: { '@': join(__dirname, 'src') } },
   test: { environment: 'jsdom', setupFiles: ['fake-indexeddb/auto'] }
 })

--- a/apps/sober-body/vitest.config.ts
+++ b/apps/sober-body/vitest.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from 'vitest/config'
 import { join } from 'path'
 
 export default defineConfig({
+  root: __dirname,
   resolve: { alias: { '@': join(__dirname, 'src') } },
   test: { environment: 'jsdom', setupFiles: ['fake-indexeddb/auto'] }
 })


### PR DESCRIPTION
## Summary
- set Vitest root directory for the Pronunco and Sober Body apps

## Testing
- `npm run -s test:unit:pc`
- `npm run -s test:unit:sb`
- `pnpm vitest run packages/core-storage/tests/db.spec.ts`


------
https://chatgpt.com/codex/tasks/task_e_686840aaad70832b86d147869c5ca43a