### PR TITLE
fix: install cypress for e2e tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "devDependencies": {
     "fake-indexeddb": "latest",
     "vitest": "^1.6.1",
-    "@testing-library/user-event": "^14.6.1"
+    "@testing-library/user-event": "^14.6.1",
+    "cypress": "^14.5.1"
   }
 }


### PR DESCRIPTION
## Summary
- add Cypress to root `devDependencies`

## Testing
- `pnpm -r lint`
- `pnpm -r test`
- `pnpm test:e2e:pc` *(fails: Cypress binary missing)*

------
https://chatgpt.com/codex/tasks/task_e_686844295558832b99c7f4f4a6f579a4