### PR TITLE
Fix vitest root path

### DIFF
--- a/apps/pronunco/vitest.config.ts
+++ b/apps/pronunco/vitest.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from 'vitest/config'
 import { join } from 'path'
 
 export default defineConfig({
+  root: __dirname,
   resolve: { alias: { '@': join(__dirname, 'src') } },
   test: { environment: 'jsdom', setupFiles: ['fake-indexeddb/auto'] }
 })

--- a/apps/sober-body/vitest.config.ts
+++ b/apps/sober-body/vitest.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from 'vitest/config'
 import { join } from 'path'
 
 export default defineConfig({
+  root: __dirname,
   resolve: { alias: { '@': join(__dirname, 'src') } },
   test: { environment: 'jsdom', setupFiles: ['fake-indexeddb/auto'] }
 })


### PR DESCRIPTION
## Summary
- point vitest config root to each app directory so `import.meta.glob` can locate presets

## Testing
- `pnpm test:unit:sb`
- `pnpm test:unit:pc`


------
https://chatgpt.com/codex/tasks/task_e_68684777ef58832b891d6046421fc4d7