### PR TITLE
Fix dev script prerequisites

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,8 +17,9 @@
     "lint": "pnpm -r lint"
   },
   "devDependencies": {
+    "@testing-library/user-event": "^14.6.1",
+    "concurrently": "^9.2.0",
     "fake-indexeddb": "latest",
-    "vitest": "^1.6.1",
-    "@testing-library/user-event": "^14.6.1"
+    "vitest": "^1.6.1"
   }
 }

--- a/packages/core-storage/vitest.config.ts
+++ b/packages/core-storage/vitest.config.ts
@@ -1,0 +1,5 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: { environment: 'jsdom', setupFiles: ['fake-indexeddb/auto'] }
+})


### PR DESCRIPTION
## Summary
- add `concurrently` to root devDependencies
- configure Vitest for `core-storage`

## Testing
- `pnpm -r lint`
- `pnpm -r test`
- `./scripts/dev.sh -t` (terminated after launch)

------
https://chatgpt.com/codex/tasks/task_e_6868791771d0832b9ce7813f3453c7c6