### PR TITLE
feat(dev): warn if local changes present before pull

### DIFF
--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -29,6 +29,10 @@ done
 
 if $RUN_PULL; then
   echo "Pulling latest changes..."
+  if ! git diff-index --quiet HEAD --; then
+    echo "Error: local changes detected. Please commit, stash, or discard them before pulling."
+    exit 1
+  fi
   git pull
 fi
 


### PR DESCRIPTION
## Summary
- detect unstaged changes in `scripts/dev.sh` when using `--pull`
- abort with a helpful message if uncommitted files would block `git pull`

## Testing
- `pnpm -r lint`
- `pnpm -r test`


------
https://chatgpt.com/codex/tasks/task_e_68687dc3f580832bb8c5594a3e5a8d31