### PR TITLE
Wire PronunCo deck manager

### DIFF
--- a/apps/pronunco/package.json
+++ b/apps/pronunco/package.json
@@ -4,21 +4,25 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "vite",
+    "dev": "vite --open /decks",
     "build": "tsc -b && vite build",
     "test": "vitest run"
   },
   "dependencies": {
+    "dexie-react-hooks": "^1.1.7",
     "react": "^19.1.0",
-    "react-dom": "^19.1.0"
+    "react-dom": "^19.1.0",
+    "react-router-dom": "^6.30.1"
   },
   "devDependencies": {
+    "@testing-library/react": "^16.3.0",
+    "jszip": "^3.10.1",
+    "@types/react": "^19.1.2",
+    "@types/react-dom": "^19.1.2",
     "@vitejs/plugin-react": "^4.4.1",
+    "fake-indexeddb": "^5.0.2",
     "typescript": "~5.8.3",
     "vite": "^6.3.5",
-    "vitest": "^1.6.1",
-    "fake-indexeddb": "^5.0.2",
-    "@types/react": "^19.1.2",
-    "@types/react-dom": "^19.1.2"
+    "vitest": "^1.6.1"
   }
 }

--- a/apps/pronunco/src/App.tsx
+++ b/apps/pronunco/src/App.tsx
@@ -1,0 +1,16 @@
+import { Routes, Route, Navigate } from 'react-router-dom'
+import DeckManager from './components/DeckManager'
+
+function DrillPage() {
+  return <div>Drill placeholder</div>
+}
+
+export default function App() {
+  return (
+    <Routes>
+      <Route path="/" element={<Navigate to="/decks" replace />} />
+      <Route path="/decks" element={<DeckManager />} />
+      <Route path="/coach" element={<DrillPage />} />
+    </Routes>
+  )
+}

--- a/apps/pronunco/src/components/DeckManager.tsx
+++ b/apps/pronunco/src/components/DeckManager.tsx
@@ -1,0 +1,77 @@
+import { useRef } from 'react'
+import { useLiveQuery } from 'dexie-react-hooks'
+import { db, resetDB } from '../db'
+import { importDeckZip, importDeckFolder } from '../../../../packages/core-storage/src/import-decks'
+
+export default function DeckManager() {
+  const zipRef = useRef<HTMLInputElement>(null)
+  const folderRef = useRef<HTMLInputElement>(null)
+  const decks = useLiveQuery(() => db.decks.toArray(), [], []) || []
+
+  const handleZip = async (file: File) => {
+    await importDeckZip(file, db)
+  }
+
+  const handleFolderFiles = async (files: FileList | File[]) => {
+    await importDeckFolder(files, db)
+  }
+
+  const handleFolder = async () => {
+    if ('showDirectoryPicker' in window) {
+      try {
+        // @ts-ignore
+        const dir = await window.showDirectoryPicker()
+        const files: File[] = []
+        for await (const entry of dir.values()) {
+          if (entry.kind === 'file' && entry.name.endsWith('.json')) {
+            files.push(await entry.getFile())
+          }
+        }
+        if (files.length) await handleFolderFiles(files)
+      } catch {}
+    } else {
+      folderRef.current?.click()
+    }
+  }
+
+  const clearDecks = async () => {
+    await db.delete()
+    resetDB()
+  }
+
+  return (
+    <div className="p-4 space-y-2">
+      <h2 className="text-lg">Deck Manager (beta)</h2>
+      <label className="block cursor-pointer border px-2">
+        Import ZIP
+        <input
+          ref={zipRef}
+          type="file"
+          accept="application/zip"
+          className="hidden"
+          onChange={e => e.target.files && handleZip(e.target.files[0])}
+        />
+      </label>
+      <input
+        ref={folderRef}
+        type="file"
+        accept=".json"
+        multiple
+        webkitdirectory=""
+        className="hidden"
+        onChange={e => e.target.files && handleFolderFiles(e.target.files)}
+      />
+      <button className="border px-2" onClick={handleFolder}>
+        Import folder (beta)
+      </button>
+      <button className="border px-2" title="Clear decks" onClick={clearDecks}>
+        Clear decks (beta)
+      </button>
+      <ul>
+        {decks.map(d => (
+          <li key={d.id}>{d.title} – {d.lang}</li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/apps/pronunco/src/main.tsx
+++ b/apps/pronunco/src/main.tsx
@@ -1,61 +1,16 @@
-import { useEffect, useRef, useState } from 'react'
+import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
-import { db, resetDB } from './db'
-import { importDeckZip, importDeckFolder } from '../../../packages/core-storage/src/import-decks'
-
-function Beta() {
-  const [decks, setDecks] = useState<any[]>([])
-  const zipRef = useRef<HTMLInputElement>(null)
-  const refresh = async () => {
-    setDecks(await db.decks.toArray())
-  }
-  useEffect(() => {
-    refresh()
-  }, [])
-  const handleZip = async (f: File) => {
-    await importDeckZip(f, db)
-    refresh()
-  }
-  const handleFolder = async (list: FileList) => {
-    await importDeckFolder(list, db)
-    refresh()
-  }
-  return (
-    <div className="p-4 space-y-2">
-      <h2 className="text-lg">Deck Manager (beta)</h2>
-      <label className="block cursor-pointer border px-2">
-        Import ZIP
-        <input
-          ref={zipRef}
-          type="file"
-          accept="application/zip"
-          className="hidden"
-          onChange={e => e.target.files && handleZip(e.target.files[0])}
-        />
-      </label>
-      <label className="block cursor-pointer border px-2">
-        Import folder
-        <input
-          type="file"
-          accept=".json"
-          multiple
-          webkitdirectory=""
-          className="hidden"
-          onChange={e => e.target.files && handleFolder(e.target.files)}
-        />
-      </label>
-      <button className="border px-2" onClick={async () => { await db.delete(); resetDB(); refresh() }}>
-        Clear decks (beta)
-      </button>
-      <ul>
-        {decks.map(d => (
-          <li key={d.id}>{d.title} – {d.lang}</li>
-        ))}
-      </ul>
-    </div>
-  )
-}
+import { BrowserRouter } from 'react-router-dom'
+import App from './App'
 
 createRoot(document.getElementById('root')!).render(
-  import.meta.env.VITE_DECK_V2 === 'true' ? <Beta /> : <div>Hello PronunCo</div>
+  import.meta.env.VITE_DECK_V2 === 'true' ? (
+    <StrictMode>
+      <BrowserRouter>
+        <App />
+      </BrowserRouter>
+    </StrictMode>
+  ) : (
+    <div>Hello PronunCo</div>
+  )
 )

--- a/apps/pronunco/test/deck-manager.test.tsx
+++ b/apps/pronunco/test/deck-manager.test.tsx
@@ -1,0 +1,38 @@
+import React from 'react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { describe, it, expect, beforeEach } from 'vitest'
+import 'fake-indexeddb/auto'
+import JSZip from 'jszip'
+import DeckManager from '../src/components/DeckManager'
+import { db, resetDB } from '../src/db'
+import { MemoryRouter } from 'react-router-dom'
+
+beforeEach(async () => {
+  await db.delete()
+  resetDB()
+  await db.open()
+})
+
+describe('DeckManager import', () => {
+  it('imports decks from zip', async () => {
+    const zip = new JSZip()
+    zip.file('decks/a.json', JSON.stringify({ id: 'a', title: 'A', lang: 'en', lines: ['x'] }))
+    zip.file('decks/b.json', JSON.stringify({ id: 'b', title: 'B', lang: 'en', lines: ['y'] }))
+    const blob = await zip.generateAsync({ type: 'blob' })
+    const file = new File([blob], 'decks.zip')
+
+    render(
+      <MemoryRouter>
+        <DeckManager />
+      </MemoryRouter>
+    )
+    const input = screen.getByLabelText(/import zip/i)
+    fireEvent.change(input, { target: { files: [file] } })
+
+    await waitFor(async () => {
+      expect(await db.decks.count()).toBe(2)
+    })
+    const rows = await screen.findAllByRole('listitem')
+    expect(rows).toHaveLength(2)
+  })
+})

--- a/apps/pronunco/tsconfig.json
+++ b/apps/pronunco/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": ["src", "test"]
+}


### PR DESCRIPTION
## Summary
- create DeckManager component backed by Dexie
- replace entrypoint with router and DeckManager page
- open dev server to `/decks`
- add vitest for DeckManager zip import
- install testing helpers and react-router
- add tsconfig for PronunCo

## Testing
- `pnpm test:unit:sb`
- `pnpm test:unit:pc`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68689f1c8350832bbd29c3d8fa435ec9