### PR TITLE
feat(dev): log env vars at startup

### DIFF
--- a/apps/pronunco/vite.config.ts
+++ b/apps/pronunco/vite.config.ts
@@ -1,10 +1,18 @@
-import { defineConfig } from 'vite'
+import { defineConfig, loadEnv } from 'vite'
 import react from '@vitejs/plugin-react'
 import { join } from 'path'
 
-export default defineConfig({
-  envDir: join(__dirname, '../../'),
-  plugins: [react()],
-  server: { port: 5174 },
-  test: { environment: 'jsdom' }
+export default defineConfig(({ mode }) => {
+  const envDir = join(__dirname, '../../')
+  const env = loadEnv(mode, envDir)
+  console.log('PronunCo env vars:')
+  for (const [key, value] of Object.entries(env)) {
+    console.log(`  ${key}=${value}`)
+  }
+  return {
+    envDir,
+    plugins: [react()],
+    server: { port: 5174 },
+    test: { environment: 'jsdom' }
+  }
 })

--- a/apps/sober-body/vite.config.ts
+++ b/apps/sober-body/vite.config.ts
@@ -1,13 +1,21 @@
-import { defineConfig } from 'vite'
+import { defineConfig, loadEnv } from 'vite'
 import react from '@vitejs/plugin-react'
 import { join } from 'path'
 
 // https://vite.dev/config/
-export default defineConfig({
-  // 👉  point two levels up to the repo root
-  envDir: join(__dirname, '../../'),
-  plugins: [react()],
-  test: {
-    environment: 'jsdom',
-  },
+export default defineConfig(({ mode }) => {
+  const envDir = join(__dirname, '../../')
+  const env = loadEnv(mode, envDir)
+  console.log('Sober-Body env vars:')
+  for (const [key, value] of Object.entries(env)) {
+    console.log(`  ${key}=${value}`)
+  }
+  return {
+    // 👉  point two levels up to the repo root
+    envDir,
+    plugins: [react()],
+    test: {
+      environment: 'jsdom',
+    },
+  }
 })


### PR DESCRIPTION
## Summary
- show loaded Vite env vars when the dev servers start

## Testing
- `pnpm -r lint`
- `pnpm -r test`


------
https://chatgpt.com/codex/tasks/task_e_6868a346b760832ba370753b9f2afb80