### PR TITLE
Remove deck flag and mount PronunCo at /pc

### DIFF
--- a/.env.pc
+++ b/.env.pc
@@ -1,1 +1,0 @@
-VITE_DECK_V2=true

--- a/.env.sb
+++ b/.env.sb
@@ -1,1 +1,0 @@
-VITE_DECK_V2=false

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ not installed. Use `--pull` to pull the latest changes (local modifications are
 stashed and restored automatically), `--install` to run `pnpm install` before
 starting and `--test` to run unit tests. The URLs open automatically in
 Microsoft Edge at <http://localhost:5173> (Sober-Body) and
-<http://localhost:5174> (PronunCo). Other browsers have partial Web Speech API
+<http://localhost:5174/pc/decks> (PronunCo). Other browsers have partial Web Speech API
 support, so Edge is launched explicitly.
 
 Environment variables come from `.env.local` in the repo root:
@@ -34,12 +34,11 @@ VITE_TRANSLATOR_REGION=your-region
 VITE_TRANSLATOR_ENDPOINT=https://<your-translator>.cognitiveservices.azure.com
 ```
 
-Default flags: `VITE_DECK_V2=true` for PronunCo, `false` for Sober-Body.
 
 ### Common commands
 
 - `pnpm dev:sb` – start Sober-Body
-- `pnpm dev:pc` – start PronunCo
+- `pnpm dev:pc` – start PronunCo at `/pc`
 - `pnpm test:unit` – unit tests for both apps
 - `pnpm lint` – lint the code
 - `pnpm build --filter apps/sober-body` – example production build

--- a/apps/pronunco/.env.pc
+++ b/apps/pronunco/.env.pc
@@ -1,1 +1,0 @@
-VITE_DECK_V2=true

--- a/apps/pronunco/src/main.tsx
+++ b/apps/pronunco/src/main.tsx
@@ -4,13 +4,9 @@ import { BrowserRouter } from 'react-router-dom'
 import App from './App'
 
 createRoot(document.getElementById('root')!).render(
-  import.meta.env.VITE_DECK_V2 === 'true' ? (
-    <StrictMode>
-      <BrowserRouter>
-        <App />
-      </BrowserRouter>
-    </StrictMode>
-  ) : (
-    <div>Hello PronunCo</div>
-  )
+  <StrictMode>
+    <BrowserRouter basename="/pc">
+      <App />
+    </BrowserRouter>
+  </StrictMode>
 )

--- a/apps/pronunco/vite.config.ts
+++ b/apps/pronunco/vite.config.ts
@@ -10,6 +10,7 @@ export default defineConfig(({ mode }) => {
     console.log(`  ${key}=${value}`)
   }
   return {
+    base: '/pc/',
     envDir,
     plugins: [react()],
     server: { port: 5174 },

--- a/apps/sober-body/.env.sb
+++ b/apps/sober-body/.env.sb
@@ -1,1 +1,0 @@
-VITE_DECK_V2=false

--- a/apps/sober-body/src/components/DeckToolbar.tsx
+++ b/apps/sober-body/src/components/DeckToolbar.tsx
@@ -1,8 +1,7 @@
 import { useRef } from 'react'
 import type { Deck } from '../features/games/deck-types'
-import { exportZip, importZip } from '../features/games/zip-utils'
-import { saveDeck } from '../features/games/deck-storage'
-import { saveBrief, loadBrief, type BriefDoc } from '../brief-storage'
+import { exportZip } from '../features/games/zip-utils'
+import { loadBrief, type BriefDoc } from '../brief-storage'
 import { importDeckZip, importDeckFolder } from '../../../../packages/core-storage/src/import-decks'
 import { db } from '../db'
 
@@ -12,26 +11,17 @@ export default function DeckToolbar({
   onNew,
   onPaste,
   onFile,
-  onFolder,
 }: {
   decks: Deck[]
   refresh: () => void
   onNew: () => void
   onPaste: () => void
   onFile: (file: File) => void
-  onFolder: (files: FileList) => void
 }) {
   const zipRef = useRef<HTMLInputElement>(null)
   const handleZipImport = async (file: File) => {
-    if (import.meta.env.VITE_DECK_V2 === 'true') {
-      await importDeckZip(file, db)
-      refresh()
-    } else {
-      const { decks: ds, briefs } = await importZip(file)
-      for (const d of ds) await saveDeck(d)
-      for (const b of briefs) await saveBrief(b)
-      refresh()
-    }
+    await importDeckZip(file, db)
+    refresh()
   }
   const handleZipExport = async () => {
     const briefs: BriefDoc[] = []
@@ -72,11 +62,7 @@ export default function DeckToolbar({
           className="hidden"
           onChange={e => {
             if (!e.target.files) return
-            if (import.meta.env.VITE_DECK_V2 === 'true') {
-              importDeckFolder(e.target.files, db).then(refresh)
-            } else {
-              onFolder(e.target.files)
-            }
+            importDeckFolder(e.target.files, db).then(refresh)
           }}
         />
       </label>

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -92,14 +92,13 @@ Start both dev servers with `pnpm run dev:all`.
 
 ## Deck-v2 (Dexie)
 
-Deck data is migrating from a single `idb-keyval` blob to Dexie tables. When
-`VITE_DECK_V2` is enabled the app writes to:
+Deck data is stored in Dexie tables. Import helpers keep the legacy `idb-keyval`
+blob in sync for older builds. Dexie tables:
 
 - `decks`: `id`, `title`, `lang`, `category`, `updatedAt`
 - `cards`: `id`, `deckId`
 
-Import helpers use Dexie transactions and keep the legacy blob in sync while the
-flag is off.
+Import helpers use Dexie transactions and keep the legacy blob in sync.
 
 ---
 

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -13,6 +13,7 @@ Legend: **↑ = next up** · ✅ done · ⬜ open
 * ✅ **feat(core):** Widmark `bac.ts` stub 〣 PR #1
 * ✅ **test(core):** baseline BAC unit tests (`e367648`)
 * ✅ **feat(core):** parameterise elimination β from settings (`b4f609a`)
+* ✅ **chore:** remove `VITE_DECK_V2` flag; PronunCo served from `/pc`
 
 ## UI & UX
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   ],
   "scripts": {
     "dev:sb": "pnpm --filter ./apps/sober-body dev",
-    "dev:pc": "pnpm --filter ./apps/pronunco dev",
+    "dev:pc": "cd apps/pronunco && vite --base /pc/ --open /pc/decks",
     "dev:all": "concurrently -k \"pnpm dev:sb\" \"pnpm dev:pc\"",
     "test:unit:sb": "vitest run -c apps/sober-body/vitest.config.ts",
     "test:unit:pc": "vitest run -c apps/pronunco/vitest.config.ts",

--- a/packages/core-storage/src/import-decks.ts
+++ b/packages/core-storage/src/import-decks.ts
@@ -27,7 +27,6 @@ function toRows(decks: any[]): { decks: Deck[]; cards: Card[] } {
 }
 
 async function dualWriteLegacy(decks: any[]) {
-  if (import.meta.env.VITE_DECK_V2 === 'true') return
   const arr = (await get(LEGACY_KEY)) ?? []
   arr.push(...decks)
   await set(LEGACY_KEY, arr)

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -60,9 +60,9 @@ fi
 
 echo "➡  Opening Microsoft Edge at:"
 echo "   • http://localhost:5173  (Sober-Body)"
-echo "   • http://localhost:5174  (PronunCo beta)"
+echo "   • http://localhost:5174/pc/decks  (PronunCo)"
 if command -v microsoft-edge >/dev/null 2>&1; then
-  microsoft-edge http://localhost:5173 http://localhost:5174 &
+  microsoft-edge http://localhost:5173 http://localhost:5174/pc/decks &
 else
   echo "Microsoft Edge not found in PATH; please open the URLs manually."
 fi


### PR DESCRIPTION
## Summary
- mount PronunCo under `/pc`
- drop `VITE_DECK_V2` checks and env files
- update dev script and docs
- simplify deck import paths

## Testing
- `pnpm lint`
- `pnpm test:unit:sb`
- `pnpm test:unit:pc`
- `pnpm test:unit`

------
https://chatgpt.com/codex/tasks/task_e_686933937f50832bb7affe5bc0d90bc0