### PR TITLE
Free dev ports before running servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,12 @@ Start the dev servers with:
 The script checks for `tmux` and falls back to a single-terminal mode when it's
 not installed. Use `--pull` to pull the latest changes (local modifications are
 stashed and restored automatically), `--install` to run `pnpm install` before
-starting and `--test` to run unit tests. The URLs open automatically in
-Microsoft Edge at <http://localhost:5173> (Sober-Body) and
-<http://localhost:5174/pc/decks> (PronunCo). Other browsers have partial Web Speech API
-support, so Edge is launched explicitly.
+starting and `--test` to run unit tests. Before launching the dev servers it
+automatically frees ports 5173 and 5174, killing any leftover processes using
+them. The URLs open automatically in Microsoft Edge at
+<http://localhost:5173> (Sober-Body) and <http://localhost:5174/pc/decks>
+(PronunCo). Other browsers have partial Web Speech API support, so Edge is
+launched explicitly.
 
 Environment variables come from `.env.local` in the repo root:
 

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -12,6 +12,17 @@ RUN_PULL=false
 RUN_TESTS=false
 RUN_INSTALL=false
 STASHED=false
+DEV_PORTS=(5173 5174)
+
+free_port() {
+  local port=$1
+  local pids
+  pids=$(lsof -ti tcp:"$port" 2>/dev/null)
+  if [[ -n "$pids" ]]; then
+    echo "Freeing port $port (killing $pids)"
+    kill -9 $pids || true
+  fi
+}
 
 while [[ $# -gt 0 ]]; do
   case $1 in
@@ -57,6 +68,11 @@ if $RUN_TESTS; then
   echo "Running unit tests..."
   pnpm test:unit
 fi
+
+# Ensure dev ports are free before starting servers
+for port in "${DEV_PORTS[@]}"; do
+  free_port "$port"
+done
 
 echo "➡  Opening Microsoft Edge at:"
 echo "   • http://localhost:5173  (Sober-Body)"


### PR DESCRIPTION
## Summary
- update `dev.sh` to kill processes using ports 5173 and 5174
- document automatic port cleanup in README

## Testing
- `pnpm test:unit`

------
https://chatgpt.com/codex/tasks/task_e_6869404a53b4832bb5269006334b8be4