### PR TITLE
feat(scripts): report port status

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ not installed. Use `--pull` to pull the latest changes (local modifications are
 stashed and restored automatically), `--install` to run `pnpm install` before
 starting and `--test` to run unit tests. Before launching the dev servers it
 automatically frees ports 5173 and 5174, killing any leftover processes using
-them. The URLs open automatically in Microsoft Edge at
+them and printing which ports were freed. Once the servers are running it lists
+which ports are still in use. The URLs open automatically in Microsoft Edge at
 <http://localhost:5173> (Sober-Body) and <http://localhost:5174/pc/decks>
 (PronunCo). Other browsers have partial Web Speech API support, so Edge is
 launched explicitly.

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -34,12 +34,23 @@ ensure_port_free() {
   free_port "$port"
   for _ in {1..5}; do
     if is_port_free "$port"; then
+      echo "Port $port is free"
       return 0
     fi
     sleep 1
   done
   echo "Error: port $port is still in use" >&2
   exit 1
+}
+
+report_ports() {
+  for port in "${DEV_PORTS[@]}"; do
+    if is_port_free "$port"; then
+      echo "Port $port is free"
+    else
+      echo "Port $port is taken"
+    fi
+  done
 }
 
 verify_ports() {
@@ -121,6 +132,7 @@ if command -v tmux >/dev/null 2>&1; then
   tmux split-window -h 'pnpm dev:pc'
   sleep 2
   verify_ports
+  report_ports
   tmux attach -t sober
 else
   echo "tmux not found, starting servers in a single terminal."
@@ -128,5 +140,6 @@ else
   DEV_PID=$!
   sleep 2
   verify_ports
+  report_ports
   wait $DEV_PID
 fi


### PR DESCRIPTION
## Summary
- log which ports were freed in `dev.sh`
- show taken ports after starting dev servers
- document new messages in README

## Testing
- `pnpm -r test`
- `pnpm -r lint`


------
https://chatgpt.com/codex/tasks/task_e_68696751645c832b8a9ae25ed8184580