### PR TITLE
fix(script): try sudo when freeing dev ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ The script checks for `tmux` and falls back to a single-terminal mode when it's
 not installed. Use `--pull` to pull the latest changes (local modifications are
 stashed and restored automatically), `--install` to run `pnpm install` before
 starting and `--test` to run unit tests. Before launching the dev servers it
-automatically frees ports 5173 and 5174, killing any leftover processes using
-them and printing which ports were freed. Once the servers are running it lists
+automatically frees ports 5173 and 5174, killing any leftover processes (using
+`sudo` if necessary) and printing which ports were freed. Once the servers are running it lists
 which ports are still in use. The URLs open automatically in Microsoft Edge at
 <http://localhost:5173> (Sober-Body) and <http://localhost:5174/pc/decks>
 (PronunCo). Other browsers have partial Web Speech API support, so Edge is

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -23,6 +23,15 @@ free_port() {
   # Fallback to lsof if kill-port is unavailable or fails
   if lsof -ti :"$port" >/dev/null 2>&1; then
     lsof -ti :"$port" | xargs -r kill >/dev/null 2>&1 || true
+    if lsof -ti :"$port" >/dev/null 2>&1; then
+      echo "Port $port still taken; trying sudo..." >&2
+      if command -v pnpx >/dev/null 2>&1; then
+        sudo pnpx --yes kill-port "$port" >/dev/null 2>&1 || true
+      elif command -v npx >/dev/null 2>&1; then
+        sudo npx -y kill-port "$port" >/dev/null 2>&1 || true
+      fi
+      lsof -ti :"$port" | xargs -r sudo kill >/dev/null 2>&1 || true
+    fi
   fi
 }
 


### PR DESCRIPTION
## Summary
- ensure `scripts/dev.sh` escalates with `sudo` when ports remain busy
- update README to mention sudo port cleanup

## Testing
- `pnpm -r lint`
- `pnpm -r test`


------
https://chatgpt.com/codex/tasks/task_e_68697010d3cc832b9d70799b1cf2062e