### PR TITLE
Fix dev script port forwarding

### DIFF
--- a/apps/pronunco/package.json
+++ b/apps/pronunco/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "vite --open /decks",
+    "dev": "vite --base /pc/",
     "build": "tsc -b && vite build",
     "test": "vitest run"
   },

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   ],
   "scripts": {
     "dev:sb": "pnpm --filter ./apps/sober-body dev",
-    "dev:pc": "cd apps/pronunco && vite --base /pc/ --open /pc/decks",
+    "dev:pc": "pnpm --filter ./apps/pronunco dev",
     "dev:all": "concurrently -k \"pnpm dev:sb\" \"pnpm dev:pc\"",
     "test:unit:sb": "vitest run -c apps/sober-body/vitest.config.ts",
     "test:unit:pc": "vitest run -c apps/pronunco/vitest.config.ts",

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -17,6 +17,14 @@ PORT_SB=5173
 PORT_PC=5174
 DEV_PORTS=(5173 5174 5175 5176)
 
+edge() {
+  if command -v microsoft-edge >/dev/null 2>&1; then
+    microsoft-edge "$1" &
+  else
+    xdg-open "$1" &
+  fi
+}
+
 cleanup_tmux() {
   tmux has-session -t "$SESSION" 2>/dev/null && tmux kill-session -t "$SESSION"
 }
@@ -86,24 +94,26 @@ cleanup_ports
 echo "✅ Ports cleared. Spinning up dev servers …"
 
 echo "➡  Opening Microsoft Edge at:"
-echo "   • http://localhost:$PORT_SB  (Sober-Body)"
-if command -v microsoft-edge >/dev/null 2>&1; then
-  microsoft-edge http://localhost:$PORT_SB &
-else
-  echo "Microsoft Edge not found in PATH; please open the URL manually."
-fi
+echo "   • http://localhost:$PORT_SB/decks     (Sober-Body)"
+echo "   • http://localhost:$PORT_PC/pc/decks (PronunCo)"
+edge "http://localhost:${PORT_SB}/decks"
+edge "http://localhost:${PORT_PC}/pc/decks"
 
 if command -v tmux >/dev/null 2>&1; then
-  tmux new-session -d -s "$SESSION" "pnpm dev:sb"
-  tmux split-window -h "pnpm dev:pc"
+  tmux new-session -d -s "$SESSION" \
+    "pnpm dev:sb -- --port $PORT_SB"
+  tmux split-window -h \
+    "pnpm dev:pc -- --port $PORT_PC"
   sleep 2
   report_ports
   tmux attach-session -t "$SESSION"
 else
   echo "tmux not found, starting servers in a single terminal."
-  pnpm dev:all &
-  DEV_PID=$!
+  pnpm dev:sb -- --port "$PORT_SB" &
+  PID_SB=$!
+  pnpm dev:pc -- --port "$PORT_PC" &
+  PID_PC=$!
   sleep 2
   report_ports
-  wait $DEV_PID
+  wait $PID_SB $PID_PC
 fi


### PR DESCRIPTION
## Summary
- stop PronunCo dev script from auto-opening Chrome
- forward port to each dev server and open Edge manually

## Testing
- `pnpm -r lint`
- `pnpm -r test`

------
https://chatgpt.com/codex/tasks/task_e_68698497e964832b959f8a0e1d6e7e16