### PR TITLE
Add bulk deck operations to PronunCo

### DIFF
--- a/apps/pronunco/__tests__/bulk-ui.test.tsx
+++ b/apps/pronunco/__tests__/bulk-ui.test.tsx
@@ -1,0 +1,58 @@
+import React from 'react'
+import { render, screen, fireEvent, within } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import DeckManager from '../src/components/DeckManager'
+import { MemoryRouter } from 'react-router-dom'
+
+const decks = [
+  { id: 'a', title: 'A', lang: 'en', updatedAt: 0 },
+  { id: 'b', title: 'B', lang: 'en', updatedAt: 0 }
+]
+
+var bulkDeleteMock: any
+var mockDb: any
+vi.mock('dexie-react-hooks', () => ({ useLiveQuery: () => decks }))
+vi.mock('../src/db', () => {
+  bulkDeleteMock = vi.fn()
+  mockDb = {
+    decks: { bulkDelete: bulkDeleteMock },
+    transaction: async (_m: any, _t: any, fn: () => Promise<void>) => { await fn() }
+  }
+  return { db: mockDb }
+})
+vi.mock('../src/exportDeckZip', () => ({
+  exportDeckZip: vi.fn(async () => new Blob())
+}))
+import { exportDeckZip } from '../src/exportDeckZip'
+
+function setup() {
+  render(
+    <MemoryRouter>
+      <DeckManager />
+    </MemoryRouter>
+  )
+  const boxes = screen.getAllByLabelText('Select All')
+  fireEvent.click(boxes[boxes.length - 1])
+}
+
+describe('DeckManager bulk actions', () => {
+  it('selection toggles bar', () => {
+    setup()
+    const bars = screen.getAllByTestId('action-bar')
+    expect(bars.length).toBeGreaterThan(0)
+  })
+
+  it('export util called with ids', async () => {
+    setup()
+    fireEvent.click(screen.getAllByText(/export zip/i)[0])
+    expect(exportDeckZip).toHaveBeenCalledWith(['a', 'b'], expect.anything())
+  })
+
+  it('delete clears rows & bar hides', () => {
+    vi.stubGlobal('alert', () => {})
+    setup()
+    const bar = screen.getAllByTestId('action-bar').pop()!
+    fireEvent.click(within(bar).getByRole('button', { name: /delete/i }))
+    expect(bulkDeleteMock).toHaveBeenCalledWith(['a', 'b'])
+  })
+})

--- a/apps/pronunco/src/App.tsx
+++ b/apps/pronunco/src/App.tsx
@@ -10,7 +10,7 @@ export default function App() {
     <Routes>
       <Route path="/" element={<Navigate to="/decks" replace />} />
       <Route path="/decks" element={<DeckManager />} />
-      <Route path="/coach" element={<DrillPage />} />
+      <Route path="/coach/:id" element={<DrillPage />} />
     </Routes>
   )
 }

--- a/apps/pronunco/src/components/DeckManager.tsx
+++ b/apps/pronunco/src/components/DeckManager.tsx
@@ -1,12 +1,24 @@
-import { useRef } from 'react'
+import { useRef, useState, useEffect } from 'react'
+import { useNavigate } from 'react-router-dom'
 import { useLiveQuery } from 'dexie-react-hooks'
 import { db, resetDB } from '../db'
 import { importDeckZip, importDeckFolder } from '../../../../packages/core-storage/src/import-decks'
+import { exportDeckZip } from '../exportDeckZip'
 
 export default function DeckManager() {
   const zipRef = useRef<HTMLInputElement>(null)
   const folderRef = useRef<HTMLInputElement>(null)
+  const navigate = useNavigate()
   const decks = useLiveQuery(() => db.decks.toArray(), [], []) || []
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set())
+
+  useEffect(() => {
+    setSelectedIds(prev => {
+      const keep = new Set<string>()
+      for (const id of prev) if (decks.some(d => d.id === id)) keep.add(id)
+      return keep
+    })
+  }, [decks])
 
   const handleZip = async (file: File) => {
     await importDeckZip(file, db)
@@ -39,6 +51,38 @@ export default function DeckManager() {
     resetDB()
   }
 
+  const toggleId = (id: string) => {
+    setSelectedIds(prev => {
+      const next = new Set(prev)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
+      return next
+    })
+  }
+
+  const toggleAll = () => {
+    if (selectedIds.size === decks.length) setSelectedIds(new Set())
+    else setSelectedIds(new Set(decks.map(d => d.id)))
+  }
+
+  const onDrill = () => {
+    const id = [...selectedIds][0]
+    if (id) navigate(`/coach/${id}`)
+  }
+
+  const onExport = async () => {
+    await exportDeckZip([...selectedIds], db)
+  }
+
+  const onDelete = async () => {
+    const ids = [...selectedIds]
+    await db.transaction('rw', db.decks, async () => {
+      await db.decks.bulkDelete(ids)
+    })
+    alert(`Deleted ${ids.length} decks`)
+    setSelectedIds(new Set())
+  }
+
   return (
     <div className="p-4 space-y-2">
       <h2 className="text-lg">Deck Manager (beta)</h2>
@@ -67,11 +111,52 @@ export default function DeckManager() {
       <button className="border px-2" title="Clear decks" onClick={clearDecks}>
         Clear decks (beta)
       </button>
-      <ul>
-        {decks.map(d => (
-          <li key={d.id}>{d.title} – {d.lang}</li>
-        ))}
-      </ul>
+      <table className="w-full border-collapse">
+        <thead>
+          <tr>
+            <th className="w-8 text-center">
+              <input
+                type="checkbox"
+                aria-label="Select All"
+                checked={selectedIds.size > 0 && decks.every(d => selectedIds.has(d.id))}
+                onChange={toggleAll}
+              />
+            </th>
+            <th className="text-left">Title</th>
+            <th className="text-left">Lang</th>
+            <th className="w-8" />
+          </tr>
+        </thead>
+        <tbody>
+          {decks.map(d => (
+            <tr key={d.id} className="border-t">
+              <td className="text-center">
+                <input
+                  type="checkbox"
+                  aria-label={`Select ${d.title}`}
+                  checked={selectedIds.has(d.id)}
+                  onChange={() => toggleId(d.id)}
+                />
+              </td>
+              <td>{d.title}</td>
+              <td>{d.lang}</td>
+              <td className="text-center">
+                <button aria-label="Drill deck" onClick={() => navigate(`/coach/${d.id}`)}>
+                  ▶
+                </button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      {selectedIds.size > 0 && (
+        <div data-testid="action-bar" className="border p-2 space-x-2">
+          <button onClick={onDrill}>▶ Drill</button>
+          <button onClick={() => alert('TODO')}>📝 Edit Grammar</button>
+          <button onClick={onExport}>📤 Export ZIP</button>
+          <button onClick={onDelete}>🗑 Delete</button>
+        </div>
+      )}
     </div>
   )
 }

--- a/apps/pronunco/src/exportDeckZip.ts
+++ b/apps/pronunco/src/exportDeckZip.ts
@@ -1,0 +1,24 @@
+import JSZip from 'jszip'
+import type { AppDB } from '../../packages/core-storage/src/db'
+
+export async function exportDeckZip(ids: string[], db: AppDB): Promise<Blob> {
+  const zip = new JSZip()
+  await Promise.all(
+    ids.map(async id => {
+      const deck = await db.decks.get(id)
+      if (!deck) return
+      const cards = await db.cards.where('deckId').equals(id).toArray()
+      zip.file(
+        `decks/${id}.json`,
+        JSON.stringify({
+          id: deck.id,
+          title: deck.title,
+          lang: deck.lang,
+          tags: deck.tags,
+          lines: cards.map(c => c.text)
+        })
+      )
+    })
+  )
+  return zip.generateAsync({ type: 'blob' })
+}

--- a/apps/pronunco/test/deck-manager.test.tsx
+++ b/apps/pronunco/test/deck-manager.test.tsx
@@ -32,7 +32,7 @@ describe('DeckManager import', () => {
     await waitFor(async () => {
       expect(await db.decks.count()).toBe(2)
     })
-    const rows = await screen.findAllByRole('listitem')
-    expect(rows).toHaveLength(2)
+    await screen.findByText('A')
+    await screen.findByText('B')
   })
 })

--- a/apps/pronunco/tsconfig.json
+++ b/apps/pronunco/tsconfig.json
@@ -8,5 +8,5 @@
     "skipLibCheck": true,
     "noEmit": true
   },
-  "include": ["src", "test"]
+  "include": ["src", "test", "__tests__"]
 }


### PR DESCRIPTION
## Summary
- implement multi-select UI and action bar in DeckManager
- add exportDeckZip helper
- support `/coach/:id` route
- unit tests for bulk UI actions

## Testing
- `pnpm -F pronunco test`

------
https://chatgpt.com/codex/tasks/task_e_6869bb9270f4832b97b3600dee859f0a