### PR TITLE
Fix Pronunco drill navigation and bulk actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
 
       # unit tests (Vitest)
       - name: Unit tests
-        run: pnpm test:unit:${{ matrix.app }}
+        run: NODE_OPTIONS="--max-old-space-size=3072" pnpm test:unit:${{ matrix.app }}
 
       # end-to-end tests (Cypress)
       #- name: E2E tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,8 +32,13 @@ jobs:
         #   so the step succeeds – you can tighten this later.)
 
       # unit tests (Vitest)
-      - name: Unit tests
-        run: NODE_OPTIONS="--max-old-space-size=3072" pnpm test:unit:${{ matrix.app }}
+      - name: Unit tests (Sober Body)
+        if: matrix.app == 'sb'
+        run: NODE_OPTIONS="--max-old-space-size=3072" pnpm test:unit:sb
+
+      - name: Unit tests (PronunCo)
+        if: matrix.app == 'pc'
+        run: pnpm --filter apps/pronunco vitest run --reporter=verbose
 
       # end-to-end tests (Cypress)
       #- name: E2E tests

--- a/apps/pronunco/__tests__/deck-manager.bulk.test.tsx
+++ b/apps/pronunco/__tests__/deck-manager.bulk.test.tsx
@@ -1,0 +1,44 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import 'fake-indexeddb/auto'
+import DeckManager from '../src/components/DeckManager'
+import { db, resetDB } from '../src/db'
+import { MemoryRouter } from 'react-router-dom'
+import * as exportMod from '../src/exportDeckZip'
+
+beforeEach(async () => {
+  await db.delete()
+  resetDB()
+  await db.open()
+  await db.decks.bulkAdd([
+    { id: 'a', title: 'A', lang: 'en', updatedAt: 0 },
+    { id: 'b', title: 'B', lang: 'en', updatedAt: 0 },
+    { id: 'c', title: 'C', lang: 'en', updatedAt: 0 }
+  ])
+})
+
+describe('DeckManager bulk actions', () => {
+  it('export and delete selected decks', async () => {
+    vi.spyOn(exportMod, 'exportDeckZip').mockResolvedValue(new Blob())
+
+    const user = userEvent.setup()
+
+    render(
+      <MemoryRouter>
+        <DeckManager />
+      </MemoryRouter>
+    )
+
+    await user.click(await screen.findByLabelText('Select A'))
+    await user.click(await screen.findByLabelText('Select B'))
+
+    await user.click(screen.getByText(/export zip/i))
+    expect(exportMod.exportDeckZip).toHaveBeenCalledWith(['a', 'b'], db)
+
+    await user.click(screen.getByText(/delete/i))
+    await screen.findByText('C')
+    expect(await db.decks.count()).toBe(1)
+  })
+})

--- a/apps/pronunco/__tests__/drill-link.test.tsx
+++ b/apps/pronunco/__tests__/drill-link.test.tsx
@@ -1,0 +1,21 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, it, expect, vi } from 'vitest'
+import DeckManager from '../src/components/DeckManager'
+
+const deck = { id: 'abc123', title: 'Deck', lang: 'en', updatedAt: 0 }
+vi.mock('dexie-react-hooks', () => ({ useLiveQuery: () => [deck] }))
+vi.mock('../src/db', () => ({ db: {} }))
+
+describe('Drill link', () => {
+  it('points to coach page', () => {
+    render(
+      <MemoryRouter>
+        <DeckManager />
+      </MemoryRouter>
+    )
+    const link = screen.getByRole('link', { name: /drill deck/i })
+    expect(link.getAttribute('href')).toBe('/pc/coach/abc123')
+  })
+})

--- a/apps/pronunco/package.json
+++ b/apps/pronunco/package.json
@@ -21,6 +21,7 @@
     "@types/react-dom": "^19.1.2",
     "@vitejs/plugin-react": "^4.4.1",
     "fake-indexeddb": "^5.0.2",
+    "dexie": "^4.0.11",
     "typescript": "~5.8.3",
     "vite": "^6.3.5",
     "vitest": "^1.6.1"

--- a/apps/pronunco/src/App.tsx
+++ b/apps/pronunco/src/App.tsx
@@ -1,16 +1,24 @@
-import { Routes, Route, Navigate } from 'react-router-dom'
+import { BrowserRouter, Routes, Route, Navigate, useParams } from 'react-router-dom'
 import DeckManager from './components/DeckManager'
 
-function DrillPage() {
-  return <div>Drill placeholder</div>
+export function CoachStub() {
+  const { deckId } = useParams()
+  return (
+    <div>
+      <h3>{deckId}</h3>
+      <p>Coming soon</p>
+    </div>
+  )
 }
 
 export default function App() {
   return (
-    <Routes>
-      <Route path="/" element={<Navigate to="/decks" replace />} />
-      <Route path="/decks" element={<DeckManager />} />
-      <Route path="/coach/:id" element={<DrillPage />} />
-    </Routes>
+    <BrowserRouter basename="/pc">
+      <Routes>
+        <Route path="/" element={<Navigate to="/decks" replace />} />
+        <Route path="/decks" element={<DeckManager />} />
+        <Route path="/coach/:deckId" element={<CoachStub />} />
+      </Routes>
+    </BrowserRouter>
   )
 }

--- a/apps/pronunco/src/main.tsx
+++ b/apps/pronunco/src/main.tsx
@@ -1,12 +1,9 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
-import { BrowserRouter } from 'react-router-dom'
 import App from './App'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <BrowserRouter basename="/pc">
-      <App />
-    </BrowserRouter>
+    <App />
   </StrictMode>
 )

--- a/apps/pronunco/tests/setup-vitest.ts
+++ b/apps/pronunco/tests/setup-vitest.ts
@@ -1,0 +1,16 @@
+import 'fake-indexeddb/auto';
+import Dexie from 'dexie';
+import { afterEach } from 'vitest';
+
+// close & delete every dexie DB opened during a test file
+afterEach(async () => {
+  const names = await Dexie.getDatabaseNames();
+  await Promise.allSettled(
+    names.map(async (name) => {
+      const db = new Dexie(name);
+      await db.open().catch(() => {}); // may be closed already
+      db.close();
+      indexedDB.deleteDatabase(name);
+    }),
+  );
+});

--- a/apps/pronunco/vitest.config.ts
+++ b/apps/pronunco/vitest.config.ts
@@ -1,14 +1,15 @@
-import { defineConfig } from 'vitest/config'
-import { join } from 'path'
+import { defineConfig } from 'vitest/config';
+import { join } from 'path';
 
 export default defineConfig({
   root: __dirname,
   resolve: { alias: { '@': join(__dirname, 'src') } },
   test: {
-    environment: 'jsdom',
-    setupFiles: ['fake-indexeddb/auto'],
-    maxWorkers: 1,
-    threads: false,
-    coverage: process.env.CI ? undefined : { reporter: ['text', 'html'] }
-  }
-})
+    environment: 'jsdom',      // UI tests still need the DOM
+    threads: false,            // ← single process = no worker leak
+    isolate: false,            // keep one jsdom; saves ~100 MB/run
+    fileParallelism: false,    // serialise files; speed hit is tiny (<200 ms)
+    hookTimeout: 10_000,
+    setupFiles: ['./tests/setup-vitest.ts'],
+  },
+});

--- a/apps/pronunco/vitest.config.ts
+++ b/apps/pronunco/vitest.config.ts
@@ -4,5 +4,11 @@ import { join } from 'path'
 export default defineConfig({
   root: __dirname,
   resolve: { alias: { '@': join(__dirname, 'src') } },
-  test: { environment: 'jsdom', setupFiles: ['fake-indexeddb/auto'] }
+  test: {
+    environment: 'jsdom',
+    setupFiles: ['fake-indexeddb/auto'],
+    maxWorkers: 1,
+    threads: false,
+    coverage: process.env.CI ? undefined : { reporter: ['text', 'html'] }
+  }
 })


### PR DESCRIPTION
## Summary
- add `CoachStub` page and wrap routes with `BrowserRouter`
- update drill links to point to `/pc/coach/:id`
- make Import Folder button clickable via hidden input
- delete only selected decks in bulk
- add unit tests for drill link and bulk delete

## Testing
- `pnpm --filter ./apps/pronunco test`
- `pnpm --filter ./apps/sober-body test`

------
https://chatgpt.com/codex/tasks/task_e_6869c921ff6c832bbf9fd6b41d3e7556