### PR TITLE
Fix vitest resource cleanup

### DIFF
--- a/apps/pronunco/__tests__/bulk-ui.test.tsx
+++ b/apps/pronunco/__tests__/bulk-ui.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { render, screen, fireEvent, within } from '@testing-library/react'
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, afterAll, vi } from 'vitest'
 import DeckManager from '../src/components/DeckManager'
 import { MemoryRouter } from 'react-router-dom'
 
@@ -24,6 +24,10 @@ vi.mock('../src/exportDeckZip', () => ({
   exportDeckZip: vi.fn(async () => new Blob())
 }))
 import { exportDeckZip } from '../src/exportDeckZip'
+
+afterAll(() => {
+  vi.restoreAllMocks()
+})
 
 function setup() {
   render(

--- a/apps/pronunco/__tests__/deck-manager.bulk.test.tsx
+++ b/apps/pronunco/__tests__/deck-manager.bulk.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { describe, it, expect, beforeEach, afterAll, vi } from 'vitest'
 import 'fake-indexeddb/auto'
 import DeckManager from '../src/components/DeckManager'
 import { db, resetDB } from '../src/db'
@@ -17,6 +17,11 @@ beforeEach(async () => {
     { id: 'b', title: 'B', lang: 'en', updatedAt: 0 },
     { id: 'c', title: 'C', lang: 'en', updatedAt: 0 }
   ])
+})
+
+afterAll(async () => {
+  await db.close()
+  await db.delete()
 })
 
 describe('DeckManager bulk actions', () => {

--- a/apps/pronunco/__tests__/drill-link.test.tsx
+++ b/apps/pronunco/__tests__/drill-link.test.tsx
@@ -1,12 +1,16 @@
 import React from 'react'
 import { render, screen } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, afterAll, vi } from 'vitest'
 import DeckManager from '../src/components/DeckManager'
 
 const deck = { id: 'abc123', title: 'Deck', lang: 'en', updatedAt: 0 }
 vi.mock('dexie-react-hooks', () => ({ useLiveQuery: () => [deck] }))
 vi.mock('../src/db', () => ({ db: {} }))
+
+afterAll(() => {
+  vi.restoreAllMocks()
+})
 
 describe('Drill link', () => {
   it('points to coach page', () => {

--- a/apps/pronunco/src/db.ts
+++ b/apps/pronunco/src/db.ts
@@ -2,5 +2,6 @@ import { createAppDB } from '../../../packages/core-storage/src/db'
 
 export let db = createAppDB(import.meta.env.MODE === 'sb' ? 'sober' : 'pronun')
 export const resetDB = () => {
+  db.close()
   db = createAppDB('pronun')
 }

--- a/apps/pronunco/test/deck-manager.test.tsx
+++ b/apps/pronunco/test/deck-manager.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
-import { describe, it, expect, beforeEach } from 'vitest'
+import { describe, it, expect, beforeEach, afterAll } from 'vitest'
 import 'fake-indexeddb/auto'
 import JSZip from 'jszip'
 import DeckManager from '../src/components/DeckManager'
@@ -11,6 +11,11 @@ beforeEach(async () => {
   await db.delete()
   resetDB()
   await db.open()
+})
+
+afterAll(async () => {
+  await db.close()
+  await db.delete()
 })
 
 describe('DeckManager import', () => {

--- a/apps/pronunco/vitest.config.ts
+++ b/apps/pronunco/vitest.config.ts
@@ -4,5 +4,14 @@ import { join } from 'path'
 export default defineConfig({
   root: __dirname,
   resolve: { alias: { '@': join(__dirname, 'src') } },
-  test: { environment: 'jsdom', setupFiles: ['fake-indexeddb/auto'] }
+  test: {
+    environment: 'happy-dom',
+    setupFiles: ['fake-indexeddb/auto'],
+    pool: 'threads',
+    poolOptions: {
+      threads: {
+        singleThread: true
+      }
+    }
+  }
 })

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "dev:pc": "pnpm --filter ./apps/pronunco dev",
     "dev:all": "concurrently -k \"pnpm dev:sb\" \"pnpm dev:pc\"",
     "test:unit:sb": "vitest run -c apps/sober-body/vitest.config.ts",
-    "test:unit:pc": "vitest run -c apps/pronunco/vitest.config.ts",
+    "test:unit:pc": "node --max-old-space-size=4096 node_modules/vitest/vitest.mjs run -c apps/pronunco/vitest.config.ts",
     "test:e2e:sb": "cypress run --config-file apps/sober-body/cypress.config.ts",
     "test:e2e:pc": "cypress run --config-file apps/pronunco/cypress.config.ts",
     "ci": "pnpm -r build && pnpm test:unit:sb && pnpm test:unit:pc && pnpm test:e2e:sb && pnpm test:e2e:pc",
@@ -20,6 +20,7 @@
     "@testing-library/user-event": "^14.6.1",
     "concurrently": "^9.2.0",
     "fake-indexeddb": "latest",
+    "happy-dom": "^18.0.1",
     "vitest": "^1.6.1"
   }
 }


### PR DESCRIPTION
## Summary
- close database between tests
- restore vitest mocks
- run vitest in a single thread using happy-dom
- increase Node memory for test runs

## Testing
- `pnpm test:unit:pc` *(fails: MISSING DEPENDENCY  Cannot find dependency 'happy-dom')*


------
https://chatgpt.com/codex/tasks/task_e_6869db033c4c832bbf527c4094a0e846