### PR TITLE
Fix pronunco unit test memory

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "dev:pc": "pnpm --filter ./apps/pronunco dev",
     "dev:all": "concurrently -k \"pnpm dev:sb\" \"pnpm dev:pc\"",
     "test:unit:sb": "vitest run -c apps/sober-body/vitest.config.ts",
-    "test:unit:pc": "vitest run -c apps/pronunco/vitest.config.ts",
+    "test:unit:pc": "NODE_OPTIONS=--max_old_space_size=2048 vitest run -c apps/pronunco/vitest.config.ts",
     "test:e2e:sb": "cypress run --config-file apps/sober-body/cypress.config.ts",
     "test:e2e:pc": "cypress run --config-file apps/pronunco/cypress.config.ts",
     "ci": "pnpm -r build && pnpm test:unit:sb && pnpm test:unit:pc && pnpm test:e2e:sb && pnpm test:e2e:pc",


### PR DESCRIPTION
## Summary
- increase Node heap for pronunco unit tests

## Testing
- `pnpm test:unit:pc`
- `pnpm test:unit:sb`


------
https://chatgpt.com/codex/tasks/task_e_6869ee3626ec832ba800dc25d0c41689