### PR TITLE
Fix Vitest OOM by running single worker

### DIFF
--- a/apps/pronunco/vitest.config.ts
+++ b/apps/pronunco/vitest.config.ts
@@ -4,5 +4,9 @@ import { join } from 'path'
 export default defineConfig({
   root: __dirname,
   resolve: { alias: { '@': join(__dirname, 'src') } },
-  test: { environment: 'jsdom', setupFiles: ['fake-indexeddb/auto'] }
+  test: {
+    environment: 'jsdom',
+    setupFiles: ['fake-indexeddb/auto'],
+    threads: false
+  }
 })


### PR DESCRIPTION
## Summary
- run Vitest serially in apps/pronunco to prevent OOM failures

## Testing
- `pnpm test:unit:pc`

------
https://chatgpt.com/codex/tasks/task_e_686ab8e5a7fc832b9dcbe005c1b1e101