### PR TITLE
fix memory issue with vitest on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
 
       # unit tests (Vitest)
       - name: Unit tests
-        run: pnpm test:unit:${{ matrix.app }}
+        run: NODE_OPTIONS="--max-old-space-size=3072" pnpm test:unit:${{ matrix.app }}
 
       # end-to-end tests (Cypress)
       #- name: E2E tests

--- a/apps/pronunco/vitest.config.ts
+++ b/apps/pronunco/vitest.config.ts
@@ -4,5 +4,11 @@ import { join } from 'path'
 export default defineConfig({
   root: __dirname,
   resolve: { alias: { '@': join(__dirname, 'src') } },
-  test: { environment: 'jsdom', setupFiles: ['fake-indexeddb/auto'] }
+  test: {
+    environment: 'jsdom',
+    setupFiles: ['fake-indexeddb/auto'],
+    maxWorkers: 1,
+    threads: false,
+    coverage: process.env.CI ? undefined : { reporter: ['text', 'html'] }
+  }
 })


### PR DESCRIPTION
## Summary
- run CI unit tests with more memory
- disable coverage collection on PronunCo tests during CI

## Testing
- `pnpm -r test` *(fails: RangeError in pronunco tests)*
- `pnpm -r lint`

------
https://chatgpt.com/codex/tasks/task_e_686abfcb5e2c832b95173c2499e3f344