### PR TITLE
Fix vitest worker settings for pronunco tests

### DIFF
--- a/apps/pronunco/vitest.config.ts
+++ b/apps/pronunco/vitest.config.ts
@@ -7,8 +7,7 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     setupFiles: ['fake-indexeddb/auto'],
-    maxWorkers: 1,
-    threads: false,
+    poolOptions: { threads: { minThreads: 1, maxThreads: 1 } },
     coverage: process.env.CI ? undefined : { reporter: ['text', 'html'] }
   }
 })


### PR DESCRIPTION
## Summary
- configure Vitest to explicitly use a single thread

## Testing
- `pnpm test:unit:pc`

------
https://chatgpt.com/codex/tasks/task_e_686ac85ef73c832b9e7a33adc2c51bc0