### PR TITLE
feat(import): remember last directory

### DIFF
--- a/apps/pronunco/__tests__/import-picker.test.tsx
+++ b/apps/pronunco/__tests__/import-picker.test.tsx
@@ -1,0 +1,65 @@
+import React from 'react'
+import { render, screen, fireEvent } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import DeckManager from '../src/components/DeckManager'
+import { MemoryRouter } from 'react-router-dom'
+
+const importZip = vi.fn(async () => {})
+const importFolder = vi.fn(async () => {})
+const saveLastDir = vi.fn(async () => {})
+const getLastDir = vi.fn(async () => undefined)
+
+vi.mock('dexie-react-hooks', () => ({ useLiveQuery: () => [] }))
+vi.mock('../../packages/core-storage/src/import-decks', () => ({
+  importDeckZip: (...args: any[]) => importZip(...args),
+  importDeckFolder: (...args: any[]) => importFolder(...args)
+}))
+vi.mock('../src/db', () => ({
+  db: { decks: { toArray: vi.fn() } }
+}))
+vi.mock('../../packages/core-storage/src/ui-store', () => ({
+  saveLastDir: (...args: any[]) => saveLastDir(...args),
+  getLastDir: (...args: any[]) => getLastDir(...args)
+}))
+
+function setup() {
+  render(
+    <MemoryRouter>
+      <DeckManager />
+    </MemoryRouter>
+  )
+}
+
+beforeEach(() => {
+  importZip.mockClear();
+  importFolder.mockClear();
+  saveLastDir.mockClear();
+  getLastDir.mockClear();
+  delete (window as any).showOpenFilePicker
+})
+
+describe('import pickers', () => {
+  it('falls back to hidden input', async () => {
+    setup()
+    const user = userEvent.setup()
+    const file = new File(['x'], 'd.zip', { type: 'application/zip' })
+    await user.click(screen.getByText(/import zip/i))
+    const input = screen.getByTestId('zipInput') as HTMLInputElement
+    fireEvent.change(input, { target: { files: [file] } })
+    expect(importZip).toHaveBeenCalledWith(file, expect.anything())
+    expect(input.value).toBe('')
+  })
+
+  it('uses showOpenFilePicker when available', async () => {
+    ;(window as any).showOpenFilePicker = vi.fn().mockResolvedValue([
+      { getFile: vi.fn().mockResolvedValue(new File(['x'], 'd.zip')) }
+    ])
+    setup()
+    const user = userEvent.setup()
+    await user.click(screen.getByText(/import zip/i))
+    expect(window.showOpenFilePicker).toHaveBeenCalled()
+    expect(importZip).toHaveBeenCalled()
+    expect(saveLastDir).toHaveBeenCalled()
+  })
+})

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -100,6 +100,9 @@ blob in sync for older builds. Dexie tables:
 
 Import helpers use Dexie transactions and keep the legacy blob in sync.
 
+Import picker now remembers the last directory using the File System Access API
+when available, storing the handle in `pronun-v2.ui.lastImportDir`.
+
 ---
 
 *End of file*

--- a/packages/core-storage/src/db.ts
+++ b/packages/core-storage/src/db.ts
@@ -18,13 +18,15 @@ export interface Card {
 export interface AppDB extends Dexie {
   decks: Table<Deck, string>
   cards: Table<Card, string>
+  ui: Table<any, string>
 }
 
 export const createAppDB = (app: 'sober' | 'pronun'): AppDB => {
   const db = new Dexie(`${app}-v2`)
   db.version(1).stores({
     decks: '&id,title,lang,category,updatedAt',
-    cards: 'id,deckId'
+    cards: 'id,deckId',
+    ui: '&id'
   })
   return db as AppDB
 }

--- a/packages/core-storage/src/ui-store.ts
+++ b/packages/core-storage/src/ui-store.ts
@@ -1,0 +1,14 @@
+import type Dexie from 'dexie'
+import type { AppDB } from './db'
+
+export function uiKV(db: AppDB) {
+  return db.table('ui') as Dexie.Table<any, string>
+}
+
+export async function saveLastDir(db: AppDB, h: FileSystemDirectoryHandle) {
+  await uiKV(db).put({ id: 'lastImportDir', handle: h })
+}
+
+export async function getLastDir(db: AppDB) {
+  return uiKV(db).get('lastImportDir').then(r => r?.handle as any)
+}

--- a/packages/core-storage/tests/ui-store.spec.ts
+++ b/packages/core-storage/tests/ui-store.spec.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest'
+import 'fake-indexeddb/auto'
+import { createAppDB } from '../src/db'
+import { saveLastDir, getLastDir } from '../src/ui-store'
+
+describe('ui-store', () => {
+  it('stores and retrieves last handle', async () => {
+    const db = createAppDB('pronun')
+    const handle = { kind: 'file' } as any
+    await saveLastDir(db, handle)
+    const out = await getLastDir(db)
+    expect(out).toStrictEqual(handle)
+  })
+})


### PR DESCRIPTION
## Summary
- use File System Access API for DeckManager import buttons
- persist last folder in IndexedDB
- add UI table to Dexie database
- document import picker behaviour
- test UI store and import picker logic

## Testing
- `pnpm -r test` *(fails: pronunco tests failed to run)*

------
https://chatgpt.com/codex/tasks/task_e_686aeb9e8b18832ba575a42eb8b28941