### PR TITLE
Fix DeckManager import UX

### DIFF
--- a/apps/pronunco/src/components/DeckManager.tsx
+++ b/apps/pronunco/src/components/DeckManager.tsx
@@ -1,133 +1,149 @@
-import { useRef, useState, useEffect, type ChangeEvent } from 'react'
-import { useNavigate, Link } from 'react-router-dom'
-import { useLiveQuery } from 'dexie-react-hooks'
-import { db, clearDecks as clearAllDecks } from '../db'
-import { importDeckZip, importDeckFolder } from '../../../../packages/core-storage/src/import-decks'
-import { saveLastDir, getLastDir } from '../../../../packages/core-storage/src/ui-store'
-import { exportDeckZip } from '../exportDeckZip'
+import { useRef, useState, useEffect, type ChangeEvent } from "react";
+import { useNavigate, Link } from "react-router-dom";
+import { useLiveQuery } from "dexie-react-hooks";
+import { db, clearDecks as clearAllDecks } from "../db";
+import {
+  importDeckZip,
+  importDeckFolder,
+} from "../../../../packages/core-storage/src/import-decks";
+import {
+  saveLastDir,
+  getLastDir,
+} from "../../../../packages/core-storage/src/ui-store";
+import { exportDeckZip } from "../exportDeckZip";
 
 export default function DeckManager() {
-  const zipRef = useRef<HTMLInputElement>(null)
-  const jsonRef = useRef<HTMLInputElement>(null)
-  const navigate = useNavigate()
-  const decks = useLiveQuery(() => db.decks.toArray(), [], []) || []
-  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set())
+  const zipRef = useRef<HTMLInputElement>(null);
+  const jsonRef = useRef<HTMLInputElement>(null);
+  const pickerOpen = useRef(false);
+  const navigate = useNavigate();
+  const decks = useLiveQuery(() => db.decks.toArray(), [], []) || [];
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
 
   useEffect(() => {
-    setSelectedIds(prev => {
-      const keep = new Set<string>()
-      for (const id of prev) if (decks.some(d => d.id === id)) keep.add(id)
-      return keep
-    })
-  }, [decks])
+    setSelectedIds((prev) => {
+      const keep = new Set<string>();
+      for (const id of prev) if (decks.some((d) => d.id === id)) keep.add(id);
+      return keep;
+    });
+  }, [decks]);
 
   const handleZip = async (file: File) => {
-    await importDeckZip(file, db)
-  }
+    await importDeckZip(file, db);
+  };
 
   const handleFolderFiles = async (files: FileList | File[]) => {
-    await importDeckFolder(files, db)
-  }
+    await importDeckFolder(files, db);
+  };
 
   const onZipInput = async (e: ChangeEvent<HTMLInputElement>) => {
     if (e.target.files && e.target.files[0]) {
-      await handleZip(e.target.files[0])
+      await handleZip(e.target.files[0]);
     }
-    e.target.value = ''
-  }
+    e.target.value = "";
+  };
 
   const onJsonInput = async (e: ChangeEvent<HTMLInputElement>) => {
     if (e.target.files && e.target.files.length) {
-      await handleFolderFiles(e.target.files)
+      await handleFolderFiles(e.target.files);
     }
-    e.target.value = ''
-  }
+    e.target.value = "";
+  };
 
-  const supportsFSA = 'showOpenFilePicker' in window
+  const supportsFSA = "showOpenFilePicker" in window;
+  const supportsDir = "showDirectoryPicker" in window;
 
   const pickZip = async () => {
     if (supportsFSA) {
       try {
-        const last = await getLastDir(db)
+        const last = await getLastDir(db);
         const [h] = await (window as any).showOpenFilePicker({
           multiple: false,
           types: [
-            { description: 'Zip', accept: { 'application/zip': ['.zip'] } }
+            { description: "Zip", accept: { "application/zip": [".zip"] } },
           ],
-          startIn: last
-        })
-        const file = await h.getFile()
-        await saveLastDir(db, h as any)
-        await handleZip(file)
-        return
+          startIn: last,
+        });
+        const file = await h.getFile();
+        await saveLastDir(db, h as any);
+        await handleZip(file);
+        return;
       } catch (e) {
         /* fall back */
       }
     }
-    zipRef.current?.click()
-  }
+    zipRef.current?.click();
+  };
 
   const pickJson = async () => {
-    if (supportsFSA) {
+    if (supportsDir) {
+      if (pickerOpen.current) return;
+      pickerOpen.current = true;
       try {
-        const last = await getLastDir(db)
-        const handles = await (window as any).showOpenFilePicker({
-          multiple: true,
-          startIn: last,
-          types: [
-            { description: 'JSON', accept: { 'application/json': ['.json'] } }
-          ]
-        })
-        const files = await Promise.all(handles.map((h: any) => h.getFile()))
-        if (handles[0]) await saveLastDir(db, handles[0] as any)
-        if (files.length) await handleFolderFiles(files)
-        return
+        const last = await getLastDir(db);
+        const dir = await (window as any).showDirectoryPicker({
+          startIn: last ?? "documents",
+        });
+        const fileHandles: any[] = [];
+        for await (const h of dir.values()) {
+          if (h.kind === "file" && h.name.endsWith(".json"))
+            fileHandles.push(h);
+        }
+        const files = await Promise.all(fileHandles.map((h) => h.getFile()));
+        if (files.length) {
+          await saveLastDir(db, dir as any);
+          await handleFolderFiles(files);
+        }
+        return;
       } catch (e) {
         /* fall back */
+      } finally {
+        pickerOpen.current = false;
       }
     }
-    jsonRef.current?.click()
-  }
-
+    jsonRef.current?.click();
+  };
 
   const clearDecks = async () => {
-    await clearAllDecks()
-  }
+    await clearAllDecks();
+  };
 
   const toggleId = (id: string) => {
-    setSelectedIds(prev => {
-      const next = new Set(prev)
-      if (next.has(id)) next.delete(id)
-      else next.add(id)
-      return next
-    })
-  }
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
 
   const toggleAll = () => {
-    if (selectedIds.size === decks.length) setSelectedIds(new Set())
-    else setSelectedIds(new Set(decks.map(d => d.id)))
-  }
+    if (selectedIds.size === decks.length) setSelectedIds(new Set());
+    else setSelectedIds(new Set(decks.map((d) => d.id)));
+  };
 
   const onDrill = () => {
-    const id = [...selectedIds][0]
-    if (id) navigate(`/pc/coach/${id}`)
-  }
+    const id = [...selectedIds][0];
+    if (id) navigate(`/pc/coach/${id}`);
+  };
 
   const onExport = async () => {
-    await exportDeckZip([...selectedIds], db)
-  }
+    await exportDeckZip([...selectedIds], db);
+  };
 
   async function handleDelete() {
-    await db.transaction('rw', db.decks, () =>
-      db.decks.bulkDelete([...selectedIds])
-    )
-    setSelectedIds(new Set())
+    await db.transaction("rw", db.decks, () =>
+      db.decks.bulkDelete([...selectedIds]),
+    );
+    setSelectedIds(new Set());
   }
 
   return (
     <div className="p-4 space-y-2">
       <h2 className="text-lg">Deck Manager (beta)</h2>
-      <button className="border px-2" onClick={pickZip}>Import ZIP</button>
+      <button className="border px-2" onClick={pickZip}>
+        Import ZIP
+      </button>
       <input
         data-testid="zipInput"
         id="zipInput"
@@ -160,7 +176,10 @@ export default function DeckManager() {
               <input
                 type="checkbox"
                 aria-label="Select All"
-                checked={selectedIds.size > 0 && decks.every(d => selectedIds.has(d.id))}
+                checked={
+                  selectedIds.size > 0 &&
+                  decks.every((d) => selectedIds.has(d.id))
+                }
                 onChange={toggleAll}
               />
             </th>
@@ -170,7 +189,7 @@ export default function DeckManager() {
           </tr>
         </thead>
         <tbody>
-          {decks.map(d => (
+          {decks.map((d) => (
             <tr key={d.id} className="border-t">
               <td className="text-center">
                 <input
@@ -194,11 +213,11 @@ export default function DeckManager() {
       {selectedIds.size > 0 && (
         <div data-testid="action-bar" className="border p-2 space-x-2">
           <button onClick={onDrill}>▶ Drill</button>
-          <button onClick={() => alert('TODO')}>📝 Edit Grammar</button>
+          <button onClick={() => alert("TODO")}>📝 Edit Grammar</button>
           <button onClick={onExport}>📤 Export ZIP</button>
           <button onClick={handleDelete}>🗑 Delete</button>
         </div>
       )}
     </div>
-  )
+  );
 }


### PR DESCRIPTION
## Summary
- persist previous folder handle in Dexie DB and start picker in that directory
- use `showDirectoryPicker` when available with a guard to avoid double popups
- fall back to hidden `<input webkitdirectory>` for browsers without the FSA API
- unit test verifies directory picker behaviour

## Testing
- `npx vitest run -c apps/pronunco/vitest.config.ts apps/pronunco/__tests__/import-picker.test.tsx` *(fails: Command killed as tests hang)*

------
https://chatgpt.com/codex/tasks/task_e_686b120bf83c832bab4d458fbbe5d364