### PR TITLE
Fix folder import picker

### DIFF
--- a/apps/pronunco/__tests__/import-picker.test.tsx
+++ b/apps/pronunco/__tests__/import-picker.test.tsx
@@ -74,38 +74,29 @@ describe("import pickers", () => {
     expect(order).toEqual(["save", "import"]);
   });
 
-  it("uses showDirectoryPicker for folders", async () => {
-    const fileHandle = {
-      kind: "file",
-      name: "d.json",
-      getFile: vi
-        .fn()
-        .mockResolvedValue(
-          new File(["{}"], "d.json", { type: "application/json" }),
-        ),
-    };
-    const dirHandle = {
-      values: vi.fn().mockReturnValue(
-        (async function* () {
-          yield fileHandle;
-        })(),
-      ),
-    };
-    (window as any).showDirectoryPicker = vi.fn().mockResolvedValue(dirHandle);
-    const start = { kind: "directory" };
+  it("uses showOpenFilePicker for folders", async () => {
+    const handles = [
+      {
+        getFile: vi
+          .fn()
+          .mockResolvedValue(new File(["{}"], "d.json", { type: "application/json" })),
+      },
+    ];
+    (window as any).showOpenFilePicker = vi.fn().mockResolvedValue(handles);
+    const start = { kind: "file" };
     getLastDir.mockResolvedValue(start as any);
 
     setup();
     const user = userEvent.setup();
     await user.click(screen.getByText(/import folder/i));
 
-    expect(window.showDirectoryPicker).toHaveBeenCalledWith(
-      expect.objectContaining({ startIn: start }),
+    expect(window.showOpenFilePicker).toHaveBeenCalledWith(
+      expect.objectContaining({ startIn: start, multiple: true }),
     );
-    expect(importFolder).toHaveBeenCalled();
-    expect(saveLastDir).toHaveBeenCalledWith(
+    expect(importFolder).toHaveBeenCalledWith(
       expect.anything(),
-      dirHandle as any,
+      expect.anything(),
     );
+    expect(saveLastDir).toHaveBeenCalledWith(handles[0], expect.anything());
   });
 });

--- a/apps/pronunco/src/components/DeckManager.tsx
+++ b/apps/pronunco/src/components/DeckManager.tsx
@@ -68,7 +68,8 @@ export default function DeckManager() {
         await saveLastDir(db, h as any);
         await handleZip(file);
         return;
-      } catch (e) {
+      } catch (e: any) {
+        if (e?.name === "AbortError") return;
         /* fall back */
       }
     }
@@ -76,7 +77,27 @@ export default function DeckManager() {
   };
 
   const pickJson = async () => {
-    if (supportsDir) {
+    if (supportsFSA) {
+      try {
+        const last = await getLastDir(db);
+        const handles = await (window as any).showOpenFilePicker({
+          multiple: true,
+          types: [
+            { description: "JSON", accept: { "application/json": [".json"] } },
+          ],
+          startIn: last,
+        });
+        const files = await Promise.all(handles.map((h: any) => h.getFile()));
+        if (files.length) {
+          await saveLastDir(db, handles[0] as any);
+          await handleFolderFiles(files);
+        }
+        return;
+      } catch (e: any) {
+        if (e?.name === "AbortError") return;
+        /* fall back */
+      }
+    } else if (supportsDir) {
       if (pickerOpen.current) return;
       pickerOpen.current = true;
       try {
@@ -95,7 +116,8 @@ export default function DeckManager() {
           await handleFolderFiles(files);
         }
         return;
-      } catch (e) {
+      } catch (e: any) {
+        if (e?.name === "AbortError") return;
         /* fall back */
       } finally {
         pickerOpen.current = false;


### PR DESCRIPTION
## Summary
- allow selecting multiple JSON files
- ignore AbortError when users cancel dialog
- update DeckManager import-picker tests

## Testing
- `pnpm -r lint`
- `pnpm -r test` *(fails: vitest not executing under container)*

------
https://chatgpt.com/codex/tasks/task_e_686b184466d4832bb0e1e84877c4d758