### PR TITLE
feat: move coach page to pronunco

### DIFF
--- a/apps/pronunco/__tests__/coach-page.test.tsx
+++ b/apps/pronunco/__tests__/coach-page.test.tsx
@@ -1,0 +1,37 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import { describe, it, expect, beforeEach } from 'vitest'
+import 'fake-indexeddb/auto'
+import CoachPage from '../src/pages/CoachPage'
+import { DeckProvider } from '../src/features/deck-context'
+import { SettingsProvider } from '../../sober-body/src/features/core/settings-context'
+import { db, resetDB } from '../src/db'
+
+beforeEach(async () => {
+  await db.delete()
+  resetDB()
+  await db.open()
+  await db.decks.add({ id: 'd1', title: 'D1', lang: 'en', updatedAt: 0 })
+  await db.cards.bulkAdd([
+    { id: 'c1', deckId: 'd1', text: 'hello' },
+    { id: 'c2', deckId: 'd1', text: 'bye' },
+  ])
+})
+
+describe('CoachPage', () => {
+  it('renders first prompt line', async () => {
+    render(
+      <MemoryRouter initialEntries={['/coach/d1']}>
+        <SettingsProvider>
+          <DeckProvider>
+            <Routes>
+              <Route path="/coach/:deckId" element={<CoachPage />} />
+            </Routes>
+          </DeckProvider>
+        </SettingsProvider>
+      </MemoryRouter>
+    )
+    expect(await screen.findByText('hello')).toBeInTheDocument()
+  })
+})

--- a/apps/pronunco/__tests__/deck-manager.navigate.test.tsx
+++ b/apps/pronunco/__tests__/deck-manager.navigate.test.tsx
@@ -1,0 +1,30 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, it, expect, vi } from 'vitest'
+import DeckManager from '../src/components/DeckManager'
+
+const deck = { id: '123', title: 'A', lang: 'en', updatedAt: 0 }
+vi.mock('dexie-react-hooks', () => ({ useLiveQuery: () => [deck] }))
+vi.mock('../src/db', () => ({ db: {} }))
+
+const navigateMock = vi.fn()
+vi.mock('react-router-dom', async () => {
+  const actual: any = await vi.importActual('react-router-dom')
+  return { ...actual, useNavigate: () => navigateMock }
+})
+
+describe('DeckManager drill button', () => {
+  it('navigates to coach route', async () => {
+    const user = userEvent.setup()
+    render(
+      <MemoryRouter>
+        <DeckManager />
+      </MemoryRouter>
+    )
+    await user.click(screen.getByLabelText('Select A'))
+    await user.click(screen.getByRole('button', { name: /drill/i }))
+    expect(navigateMock).toHaveBeenCalledWith('/pc/coach/123')
+  })
+})

--- a/apps/pronunco/src/App.tsx
+++ b/apps/pronunco/src/App.tsx
@@ -1,15 +1,6 @@
-import { BrowserRouter, Routes, Route, Navigate, useParams } from 'react-router-dom'
+import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom'
 import DeckManager from './components/DeckManager'
-
-export function CoachStub() {
-  const { deckId } = useParams()
-  return (
-    <div>
-      <h3>{deckId}</h3>
-      <p>Coming soon</p>
-    </div>
-  )
-}
+import CoachPage from './pages/CoachPage'
 
 export default function App() {
   return (
@@ -17,7 +8,7 @@ export default function App() {
       <Routes>
         <Route path="/" element={<Navigate to="/decks" replace />} />
         <Route path="/decks" element={<DeckManager />} />
-        <Route path="/coach/:deckId" element={<CoachStub />} />
+        <Route path="/coach/:deckId" element={<CoachPage />} />
       </Routes>
     </BrowserRouter>
   )

--- a/apps/pronunco/src/features/deck-context.tsx
+++ b/apps/pronunco/src/features/deck-context.tsx
@@ -1,0 +1,61 @@
+import React, { createContext, useContext, useEffect, useRef, useState } from 'react'
+import { db } from '../db'
+import type { Deck } from '../../sober-body/src/features/games/deck-types'
+
+export interface DeckValue {
+  decks: Deck[]
+  activeDeck: string | null
+  setActiveDeck: (id: string) => void
+}
+
+const DeckContext = createContext<DeckValue | undefined>(undefined)
+
+export function DeckProvider({ children }: { children: React.ReactNode }) {
+  const [decks, setDecks] = useState<Deck[]>([])
+  const [activeDeck, setActiveDeck] = useState<string | null>(null)
+  const loaded = useRef(false)
+
+  useEffect(() => {
+    let alive = true
+    const load = async () => {
+      const rows = await db.decks.toArray()
+      const arr: Deck[] = []
+      for (const r of rows) {
+        const cards = await db.cards.where('deckId').equals(r.id).toArray()
+        arr.push({
+          id: r.id,
+          title: r.title,
+          lang: r.lang,
+          lines: cards.map(c => c.text),
+          tags: Array.isArray(r.tags) ? (r.tags as string[]) : [],
+          updated: r.updatedAt,
+        })
+      }
+      if (alive) {
+        setDecks(arr)
+        loaded.current = true
+      }
+    }
+    load()
+    return () => {
+      alive = false
+    }
+  }, [])
+
+  return (
+    <DeckContext.Provider value={{ decks, activeDeck, setActiveDeck }}>
+      {children}
+    </DeckContext.Provider>
+  )
+}
+
+export function useDecks() {
+  const ctx = useContext(DeckContext)
+  if (!ctx) throw new Error('useDecks must be used within DeckProvider')
+  return ctx
+}
+
+export function useDeck(id: string) {
+  const { decks } = useDecks()
+  return decks.find(d => d.id === id)
+}

--- a/apps/pronunco/src/main.tsx
+++ b/apps/pronunco/src/main.tsx
@@ -1,9 +1,15 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import App from './App'
+import { SettingsProvider } from '../../sober-body/src/features/core/settings-context'
+import { DeckProvider } from './features/deck-context'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <SettingsProvider>
+      <DeckProvider>
+        <App />
+      </DeckProvider>
+    </SettingsProvider>
   </StrictMode>
 )

--- a/apps/pronunco/src/pages/CoachPage.tsx
+++ b/apps/pronunco/src/pages/CoachPage.tsx
@@ -1,0 +1,18 @@
+import { useEffect } from 'react'
+import { useParams, Navigate } from 'react-router-dom'
+import PronunciationCoachUI from '../../sober-body/src/components/PronunciationCoachUI'
+import { useDeck, useDecks } from '../features/deck-context'
+
+export default function CoachPage() {
+  const { deckId = '' } = useParams<{ deckId: string }>()
+  const { decks, setActiveDeck } = useDecks()
+  const deck = useDeck(deckId)
+
+  useEffect(() => {
+    if (deck) setActiveDeck(deck.id)
+  }, [deck, setActiveDeck])
+
+  if (decks.length > 0 && !deck) return <Navigate to="/decks" replace />
+
+  return <PronunciationCoachUI />
+}

--- a/apps/sober-body/src/pages/__tests__/coach.test.tsx
+++ b/apps/sober-body/src/pages/__tests__/coach.test.tsx
@@ -1,59 +1,16 @@
-import { render, screen, waitFor } from '@testing-library/react'
-import { MemoryRouter, Routes, Route } from 'react-router-dom'
-import { describe, it, expect, vi } from 'vitest'
-import 'fake-indexeddb/auto'
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, it, expect } from 'vitest'
 import CoachPage from '../coach'
-import { DeckProvider, useDecks } from '../../features/games/deck-context'
-import { SettingsProvider } from '../../features/core/settings-context'
 
-const decks = [
-  { id: 'abc', title: 'Test', lang: 'en', lines: ['x'], tags: [] as string[] }
-]
-
-vi.mock('../../features/games/deck-storage', () => ({
-  loadDecks: vi.fn(async () => decks),
-  saveDecks: vi.fn(),
-}))
-
-function ActiveDisplay() {
-  const { activeDeck } = useDecks()
-  return <div data-testid="active">{activeDeck}</div>
-}
-
-describe('CoachPage routing', () => {
-  it('loads deck from param path', async () => {
+describe('CoachPage link', () => {
+  it('links to PronunCo', () => {
     render(
-      <MemoryRouter initialEntries={['/coach/deck/abc']}>
-        <SettingsProvider>
-          <DeckProvider>
-            <Routes>
-              <Route path="/coach/deck/:id" element={<><CoachPage /><ActiveDisplay /></>} />
-            </Routes>
-          </DeckProvider>
-        </SettingsProvider>
+      <MemoryRouter>
+        <CoachPage />
       </MemoryRouter>
     )
-    await waitFor(() => {
-      expect(screen.getByTestId('active').textContent).toBe('abc')
-    })
-  })
-
-  it('skips warning once decks are ready', async () => {
-    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
-    render(
-      <MemoryRouter initialEntries={['/coach/deck/abc']}>
-        <SettingsProvider>
-          <DeckProvider>
-            <Routes>
-              <Route path="/coach/deck/:id" element={<><CoachPage /><ActiveDisplay /></>} />
-            </Routes>
-          </DeckProvider>
-        </SettingsProvider>
-      </MemoryRouter>
-    )
-    const nodes = await screen.findAllByTestId('active')
-    expect(nodes[0].textContent).toBe('abc')
-    expect(warn).not.toHaveBeenCalled()
-    warn.mockRestore()
+    const link = screen.getByRole('link')
+    expect(link.getAttribute('href')).toBe('/pc/coach')
   })
 })

--- a/apps/sober-body/src/pages/coach.tsx
+++ b/apps/sober-body/src/pages/coach.tsx
@@ -1,18 +1,11 @@
-import { useEffect } from 'react'
-import { useParams, Navigate } from 'react-router-dom'
-import PronunciationCoachUI from '../components/PronunciationCoachUI'
-import { useDeck, useDecks } from '../features/games/deck-context'
+import { Link } from 'react-router-dom'
 
 export default function CoachPage() {
-  const { id = '' } = useParams<{ id: string }>()
-  const { decks, setActiveDeck } = useDecks()
-  const deck = useDeck(id)
-
-  useEffect(() => {
-    if (deck) setActiveDeck(deck.id)
-  }, [deck, setActiveDeck])
-
-  if (decks.length > 0 && !deck) return <Navigate to="/decks" replace />
-
-  return <PronunciationCoachUI />
+  return (
+    <div className="p-4">
+      <Link to="/pc/coach" className="border rounded p-4 block max-w-sm mx-auto text-center">
+        Practice decks in PronunCo ➜
+      </Link>
+    </div>
+  )
 }


### PR DESCRIPTION
## Summary
- route `/pc/coach/:deckId` in PronunCo
- add dexie-backed deck context
- render coach UI with PronunCo route
- wrap PronunCo app with SettingsProvider and DeckProvider
- simplify Sober‑Body coach route to link to PronunCo
- tests for drill navigation and PronunCo coach page

## Testing
- `pnpm run test:unit:sb`
- `pnpm exec vitest run -c apps/pronunco/vitest.config.ts` *(fails: RangeError: Invalid count value)*

------
https://chatgpt.com/codex/tasks/task_e_686b2c239974832bb022ad6dbf549661