### PR TITLE
Move PronunciationCoachUI into shared package

### DIFF
--- a/apps/pronunco/package.json
+++ b/apps/pronunco/package.json
@@ -12,7 +12,8 @@
     "dexie-react-hooks": "^1.1.7",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "react-router-dom": "^6.30.1"
+    "react-router-dom": "^6.30.1",
+    "coach-ui": "workspace:*"
   },
   "devDependencies": {
     "@testing-library/react": "^16.3.0",

--- a/apps/pronunco/src/pages/CoachPage.tsx
+++ b/apps/pronunco/src/pages/CoachPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from 'react'
 import { useParams, Navigate } from 'react-router-dom'
-import PronunciationCoachUI from '../../sober-body/src/components/PronunciationCoachUI'
+import { PronunciationCoachUI } from 'coach-ui'
 import { useDeck, useDecks } from '../features/deck-context'
 
 export default function CoachPage() {

--- a/apps/pronunco/vitest.config.ts
+++ b/apps/pronunco/vitest.config.ts
@@ -11,5 +11,6 @@ export default defineConfig({
     fileParallelism: false,    // serialise files; speed hit is tiny (<200 ms)
     hookTimeout: 10_000,
     setupFiles: ['./tests/setup-vitest.ts'],
+    deps: { inline: ['coach-ui'] },
   },
 });

--- a/apps/sober-body/package.json
+++ b/apps/sober-body/package.json
@@ -18,7 +18,8 @@
     "react-dom": "^19.1.0",
     "react-router-dom": "^6.30.1",
     "react-select": "^5.10.1",
-    "jszip": "^3.10.1"
+    "jszip": "^3.10.1",
+    "coach-ui": "workspace:*"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",

--- a/apps/sober-body/src/components/PronunciationCoachUI.test.tsx
+++ b/apps/sober-body/src/components/PronunciationCoachUI.test.tsx
@@ -2,7 +2,7 @@ import { render, fireEvent, screen, cleanup, waitFor } from '@testing-library/re
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { useEffect } from 'react'
 import 'fake-indexeddb/auto'
-import PronunciationCoachUI from './PronunciationCoachUI'
+import { PronunciationCoachUI } from 'coach-ui'
 import { MemoryRouter } from 'react-router-dom'
 import { SettingsProvider } from '../features/core/settings-context'
 import { DeckProvider, useDecks } from '../features/games/deck-context'

--- a/apps/sober-body/vitest.config.ts
+++ b/apps/sober-body/vitest.config.ts
@@ -4,5 +4,9 @@ import { join } from 'path'
 export default defineConfig({
   root: __dirname,
   resolve: { alias: { '@': join(__dirname, 'src') } },
-  test: { environment: 'jsdom', setupFiles: ['fake-indexeddb/auto'] }
+  test: {
+    environment: 'jsdom',
+    setupFiles: ['fake-indexeddb/auto'],
+    deps: { inline: ['coach-ui'] }
+  }
 })

--- a/packages/coach-ui/index.ts
+++ b/packages/coach-ui/index.ts
@@ -1,0 +1,1 @@
+export { default as PronunciationCoachUI } from './src/PronunciationCoachUI';

--- a/packages/coach-ui/package.json
+++ b/packages/coach-ui/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "coach-ui",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "dependencies": {
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0",
+    "react-router-dom": "^6.30.1"
+  }
+}

--- a/packages/coach-ui/src/GrammarModal.test.tsx
+++ b/packages/coach-ui/src/GrammarModal.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, cleanup } from '@testing-library/react'
 import { describe, it, expect, afterEach } from 'vitest'
 import GrammarModal from './GrammarModal'
-import type { BriefWithRefs } from '../grammar-loader'
+import type { BriefWithRefs } from '../../../apps/sober-body/src/grammar-loader'
 
 const brief: BriefWithRefs = {
   id: 'b',

--- a/packages/coach-ui/src/GrammarModal.tsx
+++ b/packages/coach-ui/src/GrammarModal.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import type { BriefWithRefs } from '../grammar-loader'
+import type { BriefWithRefs } from '../../../apps/sober-body/src/grammar-loader'
 
 export default function GrammarModal({
   open,

--- a/packages/coach-ui/src/PronunciationCoachUI.tsx
+++ b/packages/coach-ui/src/PronunciationCoachUI.tsx
@@ -1,18 +1,18 @@
-import { useState, useEffect } from 'react'
+import React, { useState, useEffect } from 'react'
 import { useNavigate } from 'react-router-dom';
-import { usePronunciationCoach } from "../features/games/PronunciationCoach";
-import type { SplitMode } from "../features/games/types";
-import { splitUnits } from "../features/games/parser";
-import useTranslation from "../../../../packages/pronunciation-coach/src/useTranslation";
-import { LANGS } from "../../../../packages/pronunciation-coach/src/langs";
-import { useSettings } from "../features/core/settings-context";
-import { useDecks } from "../features/games/deck-context";
-import type { Deck } from "../features/games/deck-types";
+import { usePronunciationCoach } from "../../../apps/sober-body/src/features/games/PronunciationCoach";
+import type { SplitMode } from "../../../apps/sober-body/src/features/games/types";
+import { splitUnits } from "../../../apps/sober-body/src/features/games/parser";
+import useTranslation from "../../pronunciation-coach/src/useTranslation";
+import { LANGS } from "../../pronunciation-coach/src/langs";
+import { useSettings } from "../../../apps/sober-body/src/features/core/settings-context";
+import { useDecks } from "../../../apps/sober-body/src/features/games/deck-context";
+import type { Deck } from "../../../apps/sober-body/src/features/games/deck-types";
 import GrammarModal from "./GrammarModal";
-import { getBriefForDeck, refs } from "../grammar-loader";
-import type { BriefWithRefs } from "../grammar-loader";
-import { loadBrief } from "../brief-storage";
-import useBriefExists from "../useBriefExists";
+import { getBriefForDeck, refs } from "../../../apps/sober-body/src/grammar-loader";
+import type { BriefWithRefs } from "../../../apps/sober-body/src/grammar-loader";
+import { loadBrief } from "../../../apps/sober-body/src/brief-storage";
+import useBriefExists from "../../../apps/sober-body/src/useBriefExists";
 
 const defaultDeck: Deck = {
   id: 'example',

--- a/packages/coach-ui/tsconfig.json
+++ b/packages/coach-ui/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../apps/sober-body/tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- create new `coach-ui` package
- move `PronunciationCoachUI` and `GrammarModal` into the package
- update imports to use `coach-ui`
- add vitest config to inline the new package during tests

## Testing
- `pnpm lint`
- `pnpm test:unit:sb`
- `pnpm test:unit:pc` *(no tests detected)*

------
https://chatgpt.com/codex/tasks/task_e_686b36245068832baa030a9d9d95f871