### PR TITLE
Fix deck drill links

### DIFF
--- a/apps/pronunco/__tests__/deck-manager.navigate.test.tsx
+++ b/apps/pronunco/__tests__/deck-manager.navigate.test.tsx
@@ -25,6 +25,6 @@ describe('DeckManager drill button', () => {
     )
     await user.click(screen.getByLabelText('Select A'))
     await user.click(screen.getByRole('button', { name: /drill/i }))
-    expect(navigateMock).toHaveBeenCalledWith('/pc/coach/123')
+    expect(navigateMock).toHaveBeenCalledWith('coach/123')
   })
 })

--- a/apps/pronunco/__tests__/drill-link.test.tsx
+++ b/apps/pronunco/__tests__/drill-link.test.tsx
@@ -16,6 +16,6 @@ describe('Drill link', () => {
       </MemoryRouter>
     )
     const link = screen.getByRole('link', { name: /drill deck/i })
-    expect(link.getAttribute('href')).toBe('/pc/coach/abc123')
+    expect(link.getAttribute('href')).toBe('coach/abc123')
   })
 })

--- a/apps/pronunco/src/components/DeckManager.tsx
+++ b/apps/pronunco/src/components/DeckManager.tsx
@@ -146,7 +146,7 @@ export default function DeckManager() {
 
   const onDrill = () => {
     const id = [...selectedIds][0];
-    if (id) navigate(`/pc/coach/${id}`);
+    if (id) navigate(`coach/${id}`);
   };
 
   const onExport = async () => {
@@ -224,7 +224,7 @@ export default function DeckManager() {
               <td>{d.title}</td>
               <td>{d.lang}</td>
               <td className="text-center">
-                <Link to={`/pc/coach/${d.id}`} aria-label="Drill deck">
+                <Link to={`coach/${d.id}`} aria-label="Drill deck">
                   ▶
                 </Link>
               </td>

--- a/apps/sober-body/src/components/DeckManagerPage.test.tsx
+++ b/apps/sober-body/src/components/DeckManagerPage.test.tsx
@@ -27,8 +27,10 @@ beforeEach(() => {
 afterEach(() => cleanup())
 
 describe('DeckManagerPage play button', () => {
-  it('navigates with deck id from visible row', async () => {
+  it('opens PronunCo deck from visible row', async () => {
     const user = userEvent.setup()
+    const open = vi.fn()
+    vi.stubGlobal('window', { ...window, open })
     render(
       <MemoryRouter>
         <DeckManagerPage />
@@ -37,20 +39,25 @@ describe('DeckManagerPage play button', () => {
 
     await screen.findByRole('option', { name: 'en' })
     await user.selectOptions(await screen.findByLabelText(/language/i, { selector: 'select' }), 'en')
-    const links = await screen.findAllByRole('link', { name: 'Start drill' })
-    expect(links[1].getAttribute('href')).toBe('/coach/deck/b')
+    const buttons = await screen.findAllByRole('button', { name: 'Start drill' })
+    await user.click(buttons[1])
+    expect(open).toHaveBeenCalledWith('/pc/coach/b', '_blank')
   })
 
-  it('navigates with deck id from third row', async () => {
+  it('opens PronunCo deck from third row', async () => {
+    const user = userEvent.setup()
+    const open = vi.fn()
+    vi.stubGlobal('window', { ...window, open })
     render(
       <MemoryRouter>
         <DeckManagerPage />
       </MemoryRouter>
     )
 
-    const links = await screen.findAllByRole('link', { name: 'Start drill' })
-    expect(links).toHaveLength(3)
-    expect(links[2].getAttribute('href')).toBe('/coach/deck/b')
+    const buttons = await screen.findAllByRole('button', { name: 'Start drill' })
+    expect(buttons).toHaveLength(3)
+    await user.click(buttons[2])
+    expect(open).toHaveBeenCalledWith('/pc/coach/b', '_blank')
   })
 })
 

--- a/apps/sober-body/src/components/DrillLink.test.tsx
+++ b/apps/sober-body/src/components/DrillLink.test.tsx
@@ -1,18 +1,16 @@
 import { render, screen } from '@testing-library/react'
-import { MemoryRouter } from 'react-router-dom'
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import DrillLink from './DrillLink'
 
 const deck = { id: 'x', title: 'X', lang: 'en', lines: [], tags: [] as string[] }
 
 describe('DrillLink', () => {
-  it('links to deck path', () => {
-    render(
-      <MemoryRouter>
-        <DrillLink deck={deck} />
-      </MemoryRouter>
-    )
-    const link = screen.getByRole('link', { name: 'Start drill' })
-    expect(link.getAttribute('href')).toBe('/coach/deck/x')
+  it('opens new tab', () => {
+    const open = vi.fn()
+    vi.stubGlobal('window', { ...window, open })
+    render(<DrillLink deck={deck} />)
+    const btn = screen.getByRole('button', { name: 'Start drill' })
+    btn.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    expect(open).toHaveBeenCalledWith('/pc/coach/x', '_blank')
   })
 })

--- a/apps/sober-body/src/components/DrillLink.tsx
+++ b/apps/sober-body/src/components/DrillLink.tsx
@@ -1,15 +1,18 @@
-import { Link } from 'react-router-dom'
 import type { Deck } from '../features/games/deck-types'
 
 export default function DrillLink({ deck }: { deck: Deck }) {
+  const handle = () => {
+    const url = `/pc/coach/${encodeURIComponent(deck.id)}`
+    window.open(url, '_blank')
+  }
   return (
-    <Link
-      to={`/coach/deck/${encodeURIComponent(deck.id)}`}
+    <button
+      onClick={handle}
       title={`Drill "${deck.title}"`}
       aria-label="Start drill"
       className="text-sky-600 text-lg"
     >
       ▶
-    </Link>
+    </button>
   )
 }


### PR DESCRIPTION
## Summary
- use relative links for PronunCo coach page
- open PronunCo coach in new tab from Sober‑Body
- update unit tests for new paths

## Testing
- `pnpm test:unit:sb`
- `pnpm test:unit:pc` *(fails: RangeError in vitest)*

------
https://chatgpt.com/codex/tasks/task_e_686b3c91d520832b90f7841449b44c6a