### PR TITLE
Fix coach route links

### DIFF
--- a/apps/pronunco/__tests__/deck-manager.navigate.test.tsx
+++ b/apps/pronunco/__tests__/deck-manager.navigate.test.tsx
@@ -25,6 +25,6 @@ describe('DeckManager drill button', () => {
     )
     await user.click(screen.getByLabelText('Select A'))
     await user.click(screen.getByRole('button', { name: /drill/i }))
-    expect(navigateMock).toHaveBeenCalledWith('coach/123')
+    expect(navigateMock).toHaveBeenCalledWith('/coach/123')
   })
 })

--- a/apps/pronunco/__tests__/drill-link.test.tsx
+++ b/apps/pronunco/__tests__/drill-link.test.tsx
@@ -16,6 +16,6 @@ describe('Drill link', () => {
       </MemoryRouter>
     )
     const link = screen.getByRole('link', { name: /drill deck/i })
-    expect(link.getAttribute('href')).toBe('coach/abc123')
+    expect(link.getAttribute('href')).toBe('/coach/abc123')
   })
 })

--- a/apps/pronunco/src/components/DeckManager.tsx
+++ b/apps/pronunco/src/components/DeckManager.tsx
@@ -146,7 +146,7 @@ export default function DeckManager() {
 
   const onDrill = () => {
     const id = [...selectedIds][0];
-    if (id) navigate(`coach/${id}`);
+    if (id) navigate(`/coach/${id}`);
   };
 
   const onExport = async () => {
@@ -224,7 +224,7 @@ export default function DeckManager() {
               <td>{d.title}</td>
               <td>{d.lang}</td>
               <td className="text-center">
-                <Link to={`coach/${d.id}`} aria-label="Drill deck">
+                <Link to={`/coach/${d.id}`} aria-label="Drill deck">
                   ▶
                 </Link>
               </td>


### PR DESCRIPTION
## Summary
- fix deck manager links to coach route
- update tests for absolute coach path

## Testing
- `pnpm exec vitest run` *(fails: Vitest startup error)*
- `curl -I http://localhost:5175/pc/coach/test`

------
https://chatgpt.com/codex/tasks/task_e_686b4756e118832b9082c3a7c8b2881e