### PR TITLE
Fix PronunCo coach route

### DIFF
--- a/apps/pronunco/src/features/deck-context.tsx
+++ b/apps/pronunco/src/features/deck-context.tsx
@@ -1,6 +1,7 @@
-import React, { createContext, useContext, useEffect, useRef, useState } from 'react'
+import React, { useContext, useEffect, useRef, useState } from 'react'
 import { db } from '../db'
 import type { Deck } from '../../sober-body/src/features/games/deck-types'
+import { DeckContext } from '../../sober-body/src/features/games/deck-context'
 
 export interface DeckValue {
   decks: Deck[]
@@ -8,7 +9,6 @@ export interface DeckValue {
   setActiveDeck: (id: string) => void
 }
 
-const DeckContext = createContext<DeckValue | undefined>(undefined)
 
 export function DeckProvider({ children }: { children: React.ReactNode }) {
   const [decks, setDecks] = useState<Deck[]>([])

--- a/apps/sober-body/src/features/games/deck-context.tsx
+++ b/apps/sober-body/src/features/games/deck-context.tsx
@@ -8,7 +8,7 @@ export interface DeckValue {
   setActiveDeck: (id: string) => void
 }
 
-const DeckContext = createContext<DeckValue | undefined>(undefined)
+export const DeckContext = createContext<DeckValue | undefined>(undefined)
 
 export function DeckProvider({ children }: { children: React.ReactNode }) {
   const [decks, setDecks] = useState<Deck[]>([])


### PR DESCRIPTION
## Summary
- export `DeckContext` from sober-body deck context
- reuse that context from PronunCo deck provider so `PronunciationCoachUI` works

## Testing
- `pnpm test:unit:sb`
- `pnpm test:unit:pc --run` *(fails: environment issues)*

------
https://chatgpt.com/codex/tasks/task_e_686b4cf78098832b9116bfd4dbc35cfb