### PR TITLE
Improve dev.sh test flag

### DIFF
--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -72,7 +72,25 @@ report_ports () {
 
 $run_pull    && { echo "↻ git pull …";      git pull --rebase --autostash; }
 $run_install && { echo "📦 pnpm install …";  pnpm install; }
-$run_tests   && { echo "🧪 running tests …"; pnpm test; }
+if $run_tests; then
+  echo -e "\n🏃‍♂️  Running unit tests with per-file timing …\n"
+
+  # Sober-Body app
+  echo "— apps/sober-body —"
+  time pnpm test:unit:sb -- --reporter=verbose
+
+  # PronunCo app
+  echo -e "\n— apps/pronunco —"
+  time pnpm test:unit:pc -- --reporter=verbose
+
+  # Shared packages  (optional – keep if/when you add tests there)
+  if pnpm m ls -r --depth=-1 | grep -qE '^packages/'; then
+    echo -e "\n— packages —"
+    time pnpm -r --filter "packages/**" exec vitest run --reporter=verbose
+  fi
+
+  echo -e "\n✅  All test suites finished."
+fi
 
 $run_start || exit 0
 


### PR DESCRIPTION
## Summary
- update `scripts/dev.sh` so `-t/--test` runs all unit tests for each workspace
  - includes verbose timing output
  - wraps each suite with `time` for wall-clock runtime

## Testing
- `pnpm install`
- `bash scripts/dev.sh -t` *(fails: No projects matched the filters)*


------
https://chatgpt.com/codex/tasks/task_e_686bbcaf22f4832bbb3699c7b9322209