### PR TITLE
Add debug output for import picker test

### DIFF
--- a/apps/pronunco/tests/helpers/setup-fake-file-picker.ts
+++ b/apps/pronunco/tests/helpers/setup-fake-file-picker.ts
@@ -13,8 +13,26 @@ export function useFakeFilePicker() {
     vi.useFakeTimers();
 
     // 2) Stub both picker APIs with resolved promises
-    vi.stubGlobal('showOpenFilePicker', vi.fn(() => Promise.resolve([dummyHandle])));
-    vi.stubGlobal('showDirectoryPicker', vi.fn(() => Promise.resolve(dummyHandle as unknown as FileSystemDirectoryHandle)));
+    vi.stubGlobal(
+      'showOpenFilePicker',
+      vi.fn(() => Promise.resolve([dummyHandle])),
+    );
+    vi.stubGlobal(
+      'showDirectoryPicker',
+      vi.fn(() =>
+        Promise.resolve(
+          { kind: 'directory', name: 'dummy' } as unknown as FileSystemDirectoryHandle,
+        ),
+      ),
+    );
+
+    // 3) Trigger change event when hidden <input type="file"> is clicked
+    vi
+      .spyOn(HTMLInputElement.prototype, 'click')
+      .mockImplementation(function () {
+        const evt = new Event('change');
+        queueMicrotask(() => this.dispatchEvent(evt));
+      });
   });
 
   afterEach(async () => {


### PR DESCRIPTION
## Summary
- add timer flush and END-TEST logs in import-picker tests
- dump open handles after the suite
- update fake file picker helper to simulate input change events

## Testing
- `pnpm vitest run __tests__/import-picker.test.tsx --reporter=verbose` *(fails: HTMLInputElement is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_686c369b1efc832b824137eac7cdb556