### PR TITLE
Add debug handles tracing

### DIFF
--- a/apps/pronunco/__tests__/import-picker.test.tsx
+++ b/apps/pronunco/__tests__/import-picker.test.tsx
@@ -1,7 +1,10 @@
+import { traceOpenHandles } from '../tests/helpers/trace-open-handles';
+traceOpenHandles();
+
 import React from "react";
 import { render, screen, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, it, expect, vi, afterAll } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import Dexie from "dexie";
 
 const nextTick = () => new Promise((r) => setTimeout(r, 0));
@@ -52,7 +55,7 @@ describe("import pickers", () => {
     await nextTick();
     expect(importZip).toHaveBeenCalledWith(file, expect.anything());
     expect(input.value).toBe("");
-    console.log("END-TEST", "falls back to hidden input");
+    console.log('✅ finished: falls back to hidden input');
   });
 
   it("uses showOpenFilePicker when available", async () => {
@@ -79,7 +82,7 @@ describe("import pickers", () => {
     expect(importZip).toHaveBeenCalled();
     expect(saveLastDir).toHaveBeenCalled();
     expect(order).toEqual(["save", "import"]);
-    console.log("END-TEST", "showOpenFilePicker available");
+    console.log('✅ finished: uses showOpenFilePicker when available');
   });
 
   it("uses showOpenFilePicker for folders", async () => {
@@ -110,15 +113,7 @@ describe("import pickers", () => {
       expect.anything(),
     );
     expect(saveLastDir).toHaveBeenCalledWith(handles[0], expect.anything());
-    console.log("END-TEST", "showOpenFilePicker folder");
+    console.log('✅ finished: uses showOpenFilePicker for folders');
   });
 });
 
-afterAll(() => {
-  // @ts-ignore – private API, safe for local debug
-  const handles = (process as any)._getActiveHandles?.() ?? [];
-  console.log(
-    '\n\ud83d\udd0d open handles inside import-picker.test.tsx:',
-    handles.map((h: any) => h.constructor?.name ?? 'Unknown'),
-  );
-});

--- a/apps/pronunco/tests/helpers/trace-open-handles.ts
+++ b/apps/pronunco/tests/helpers/trace-open-handles.ts
@@ -1,0 +1,22 @@
+import { afterAll } from 'vitest';
+
+/** Activates a 1-s interval that prints open Node handles.
+ *  Only runs when DEBUG_HANDLES=true is present in env. */
+export function traceOpenHandles() {
+  if (process.env.DEBUG_HANDLES !== 'true') return;
+
+  const tick = setInterval(() => {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore private API – fine for local debug
+    const list = (process as any)._getActiveHandles?.() ?? [];
+    // eslint-disable-next-line no-console
+    console.log(
+      '🕒 still alive –',
+      list.length,
+      'handle(s):',
+      list.map((h: any) => h.constructor?.name ?? 'Unknown'),
+    );
+  }, 1_000);
+
+  afterAll(() => clearInterval(tick));
+}

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -19,15 +19,17 @@ URL_PC="http://localhost:${PORT_PC}/pc/decks"
 # ──────────────────────────────────
 
 run_pull=false run_install=false run_tests=false run_start=false
+debug_handles=false
 [[ $# -eq 0 ]] && run_start=true        # default action
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
+    --debug-handles) debug_handles=true ;;
     -p|--pull)     run_pull=true;;
     -i|--install)  run_install=true;;
     -t|--test)     run_tests=true ;;
     -s|--start)    run_start=true ;;
-    *) echo "Usage: $0 [-p] [-i] [-t] [-s]" && exit 1;;
+    *) echo "Usage: $0 [--debug-handles] [-p] [-i] [-t] [-s]" && exit 1;;
   esac
   shift
 done
@@ -81,7 +83,11 @@ if $run_tests; then
 
   # PronunCo app
   echo -e "\n— apps/pronunco —"
-  time pnpm test:unit:pc -- --reporter=verbose
+  (
+    DEBUG_HANDLES=$debug_handles
+    time timeout 600 \
+      pnpm --filter ./apps/pronunco exec vitest run --reporter=verbose
+  )
 
   # Shared packages  (optional – keep if/when you add tests there)
   if pnpm m ls -r --depth=-1 | grep -qE '^packages/'; then


### PR DESCRIPTION
## Summary
- add a `--debug-handles` flag to `scripts/dev.sh`
- print active Node handles every second when enabled
- wire tracer into `import-picker.test.tsx`
- log each test end for easier debugging

## Testing
- `scripts/dev.sh -t` *(fails: `Vitest "deps.inline" is deprecated...`)*
- `scripts/dev.sh -t --debug-handles` *(fails: `Vitest "deps.inline" is deprecated...`)*

------
https://chatgpt.com/codex/tasks/task_e_686c3ef9cb0c832b8b904a249ecdc03a