### PR TITLE
Add super tracer for open handles

### DIFF
--- a/apps/pronunco/__tests__/import-picker.test.tsx
+++ b/apps/pronunco/__tests__/import-picker.test.tsx
@@ -1,5 +1,5 @@
-import { traceOpenHandles } from '../tests/helpers/trace-open-handles';
-traceOpenHandles();
+import { superTraceOpenHandles } from '../tests/helpers/super-trace-open-handles';
+superTraceOpenHandles();
 
 import React from "react";
 import { render, screen, fireEvent } from "@testing-library/react";
@@ -44,6 +44,7 @@ useFakeFilePicker();
 
 describe("import pickers", () => {
   it("falls back to hidden input", async () => {
+    console.log('▶ START test: fallback to hidden input');
     setup();
     const user = userEvent.setup();
     const file = new File(["x"], "d.zip", { type: "application/zip" });
@@ -55,10 +56,11 @@ describe("import pickers", () => {
     await nextTick();
     expect(importZip).toHaveBeenCalledWith(file, expect.anything());
     expect(input.value).toBe("");
-    console.log('✅ finished: falls back to hidden input');
+    console.log('✔ END   test: fallback to hidden input');
   });
 
   it("uses showOpenFilePicker when available", async () => {
+    console.log('▶ START test: uses showOpenFilePicker when available');
     (window as any).showOpenFilePicker = vi.fn().mockResolvedValue([
       {
         kind: "file",
@@ -82,10 +84,11 @@ describe("import pickers", () => {
     expect(importZip).toHaveBeenCalled();
     expect(saveLastDir).toHaveBeenCalled();
     expect(order).toEqual(["save", "import"]);
-    console.log('✅ finished: uses showOpenFilePicker when available');
+    console.log('✔ END   test: uses showOpenFilePicker when available');
   });
 
   it("uses showOpenFilePicker for folders", async () => {
+    console.log('▶ START test: uses showOpenFilePicker for folders');
     const handles = [
       {
         kind: "file",
@@ -113,7 +116,7 @@ describe("import pickers", () => {
       expect.anything(),
     );
     expect(saveLastDir).toHaveBeenCalledWith(handles[0], expect.anything());
-    console.log('✅ finished: uses showOpenFilePicker for folders');
+    console.log('✔ END   test: uses showOpenFilePicker for folders');
   });
 });
 

--- a/apps/pronunco/tests/helpers/super-trace-open-handles.ts
+++ b/apps/pronunco/tests/helpers/super-trace-open-handles.ts
@@ -1,0 +1,39 @@
+import { afterAll, beforeAll } from 'vitest';
+
+/**
+ * Streams:
+ * • a light “ticker” every 0.5 s so you know the loop is alive.
+ * • a full handle dump via wtfnode every 3 s.
+ * Automatically disabled unless DEBUG_HANDLES=true.
+ */
+export function superTraceOpenHandles() {
+  if (process.env.DEBUG_HANDLES !== 'true') return;
+
+  // Light ticker
+  const tick = setInterval(() => {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore private API
+    const handles = (process as any)._getActiveHandles?.() ?? [];
+    console.log(
+      `🕑 ${new Date().toLocaleTimeString()} – ${handles.length} live handle(s)`,
+      handles.map((h: any) => h.constructor?.name ?? 'Unknown'),
+    );
+  }, 500);
+
+  // Heavy dump
+  let dump: NodeJS.Timeout | null = null;
+  beforeAll(async () => {
+    const { dump: wtfDump } = await import('wtfnode');
+    dump = setInterval(() => {
+      console.log('===== WTFNODE DUMP START =====');
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+      wtfDump();                            // full handle + stack summary
+      console.log('=====  WTFNODE DUMP END  =====');
+    }, 3_000);
+  });
+
+  afterAll(() => {
+    clearInterval(tick);
+    dump && clearInterval(dump);
+  });
+}

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "@testing-library/user-event": "^14.6.1",
     "concurrently": "^9.2.0",
     "fake-indexeddb": "latest",
-    "vitest": "^1.6.1"
+    "vitest": "^1.6.1",
+    "wtfnode": "^0.10.0"
   },
   "packageManager": "pnpm@10.12.4+sha512.5ea8b0deed94ed68691c9bad4c955492705c5eeb8a87ef86bc62c74a26b037b08ff9570f108b2e4dbd1dd1a9186fea925e527f141c648e85af45631074680184"
 }

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -84,7 +84,7 @@ if $run_tests; then
   # PronunCo app
   echo -e "\n— apps/pronunco —"
   (
-    DEBUG_HANDLES=$debug_handles
+    DEBUG_HANDLES="${debug_handles:-false}"
     time timeout 600 \
       pnpm --filter ./apps/pronunco exec vitest run --reporter=verbose
   )


### PR DESCRIPTION
## Summary
- add `wtfnode` as a dev dependency
- add a new helper `superTraceOpenHandles` to stream active handles
- instrument PronunCo import picker tests with detailed start/end logs
- forward `DEBUG_HANDLES` flag in `scripts/dev.sh`

## Testing
- `./scripts/dev.sh -t --debug-handles` *(fails: Failed to resolve module imports)*

------
https://chatgpt.com/codex/tasks/task_e_686c46b473dc832b87696db7310d2f74