### PR TITLE
fix(ci): pass DEBUG_HANDLES flag

### DIFF
--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -34,6 +34,9 @@ while [[ $# -gt 0 ]]; do
   shift
 done
 
+# Export exact string "true" when handle tracing is requested
+DEBUG_HANDLES=${debug_handles:+true}
+
 #─── helpers ──────────────────────────────────────────────────────────────
 edge () {
   if command -v microsoft-edge >/dev/null 2>&1; then
@@ -84,7 +87,7 @@ if $run_tests; then
   # PronunCo app
   echo -e "\n— apps/pronunco —"
   (
-    DEBUG_HANDLES="${debug_handles:-false}"
+    DEBUG_HANDLES=$DEBUG_HANDLES \
     time timeout 600 \
       pnpm --filter ./apps/pronunco exec vitest run --reporter=verbose
   )


### PR DESCRIPTION
## Summary
- ensure `--debug-handles` passes string `true` to env
- forward `DEBUG_HANDLES` when running PronunCo tests

## Testing
- `pnpm -r lint`
- `timeout 30 pnpm -r test` *(fails: pronunco tests terminate with SIGTERM)*

------
https://chatgpt.com/codex/tasks/task_e_686c503452ec832bb9366f69899b225b