### PR TITLE
Enhance dev logging for PR #163

### DIFF
--- a/apps/pronunco/__tests__/bulk-ui.test.tsx
+++ b/apps/pronunco/__tests__/bulk-ui.test.tsx
@@ -37,22 +37,28 @@ function setup() {
 
 describe('DeckManager bulk actions', () => {
   it('selection toggles bar', () => {
+    console.log('▶ START: selection toggles bar');
     setup()
     const bars = screen.getAllByTestId('action-bar')
     expect(bars.length).toBeGreaterThan(0)
+    console.log('✔ END:   selection toggles bar');
   })
 
   it('export util called with ids', async () => {
+    console.log('▶ START: export util called with ids');
     setup()
     fireEvent.click(screen.getAllByText(/export zip/i)[0])
     expect(exportDeckZip).toHaveBeenCalledWith(['a', 'b'], expect.anything())
+    console.log('✔ END:   export util called with ids');
   })
 
   it('delete clears rows & bar hides', () => {
+    console.log('▶ START: delete clears rows & bar hides');
     vi.stubGlobal('alert', () => {})
     setup()
     const bar = screen.getAllByTestId('action-bar').pop()!
     fireEvent.click(within(bar).getByRole('button', { name: /delete/i }))
     expect(bulkDeleteMock).toHaveBeenCalledWith(['a', 'b'])
+    console.log('✔ END:   delete clears rows & bar hides');
   })
 })

--- a/apps/pronunco/__tests__/clear-decks.test.tsx
+++ b/apps/pronunco/__tests__/clear-decks.test.tsx
@@ -16,6 +16,7 @@ beforeEach(async () => {
 
 describe('Clear decks button', () => {
   it('refreshes list after Clear decks', async () => {
+    console.log('▶ START: refreshes list after Clear decks');
     const user = userEvent.setup()
     render(
       <MemoryRouter>
@@ -28,6 +29,7 @@ describe('Clear decks button', () => {
     await waitFor(() =>
       expect(screen.queryByText(/Groceries/)).not.toBeInTheDocument()
     )
+    console.log('✔ END:   refreshes list after Clear decks');
   })
 })
 

--- a/apps/pronunco/__tests__/coach-page.test.tsx
+++ b/apps/pronunco/__tests__/coach-page.test.tsx
@@ -21,6 +21,7 @@ beforeEach(async () => {
 
 describe('CoachPage', () => {
   it('renders first prompt line', async () => {
+    console.log('▶ START: renders first prompt line');
     render(
       <MemoryRouter initialEntries={['/coach/d1']}>
         <SettingsProvider>
@@ -33,5 +34,6 @@ describe('CoachPage', () => {
       </MemoryRouter>
     )
     expect(await screen.findByText('hello')).toBeInTheDocument()
+    console.log('✔ END:   renders first prompt line');
   })
 })

--- a/apps/pronunco/__tests__/deck-manager.bulk.test.tsx
+++ b/apps/pronunco/__tests__/deck-manager.bulk.test.tsx
@@ -21,6 +21,7 @@ beforeEach(async () => {
 
 describe('DeckManager bulk actions', () => {
   it('export and delete selected decks', async () => {
+    console.log('▶ START: export and delete selected decks');
     vi.spyOn(exportMod, 'exportDeckZip').mockResolvedValue(new Blob())
 
     const user = userEvent.setup()
@@ -40,5 +41,6 @@ describe('DeckManager bulk actions', () => {
     await user.click(screen.getByText(/delete/i))
     await screen.findByText('C')
     expect(await db.decks.count()).toBe(1)
+    console.log('✔ END:   export and delete selected decks');
   })
 })

--- a/apps/pronunco/__tests__/deck-manager.navigate.test.tsx
+++ b/apps/pronunco/__tests__/deck-manager.navigate.test.tsx
@@ -17,6 +17,7 @@ vi.mock('react-router-dom', async () => {
 
 describe('DeckManager drill button', () => {
   it('navigates to coach route', async () => {
+    console.log('▶ START: navigates to coach route');
     const user = userEvent.setup()
     render(
       <MemoryRouter>
@@ -26,5 +27,6 @@ describe('DeckManager drill button', () => {
     await user.click(screen.getByLabelText('Select A'))
     await user.click(screen.getByRole('button', { name: /drill/i }))
     expect(navigateMock).toHaveBeenCalledWith('/coach/123')
+    console.log('✔ END:   navigates to coach route');
   })
 })

--- a/apps/pronunco/__tests__/drill-link.test.tsx
+++ b/apps/pronunco/__tests__/drill-link.test.tsx
@@ -10,6 +10,7 @@ vi.mock('../src/db', () => ({ db: {} }))
 
 describe('Drill link', () => {
   it('points to coach page', () => {
+    console.log('▶ START: points to coach page');
     render(
       <MemoryRouter>
         <DeckManager />
@@ -17,5 +18,6 @@ describe('Drill link', () => {
     )
     const link = screen.getByRole('link', { name: /drill deck/i })
     expect(link.getAttribute('href')).toBe('/coach/abc123')
+    console.log('✔ END:   points to coach page');
   })
 })

--- a/apps/pronunco/__tests__/import-picker.test.tsx
+++ b/apps/pronunco/__tests__/import-picker.test.tsx
@@ -44,7 +44,7 @@ useFakeFilePicker();
 
 describe("import pickers", () => {
   it("falls back to hidden input", async () => {
-    console.log('▶ START test: fallback to hidden input');
+    console.log('▶ START: falls back to hidden input');
     setup();
     const user = userEvent.setup();
     const file = new File(["x"], "d.zip", { type: "application/zip" });
@@ -56,11 +56,11 @@ describe("import pickers", () => {
     await nextTick();
     expect(importZip).toHaveBeenCalledWith(file, expect.anything());
     expect(input.value).toBe("");
-    console.log('✔ END   test: fallback to hidden input');
+    console.log('✔ END:   falls back to hidden input');
   });
 
   it("uses showOpenFilePicker when available", async () => {
-    console.log('▶ START test: uses showOpenFilePicker when available');
+    console.log('▶ START: uses showOpenFilePicker when available');
     (window as any).showOpenFilePicker = vi.fn().mockResolvedValue([
       {
         kind: "file",
@@ -84,11 +84,11 @@ describe("import pickers", () => {
     expect(importZip).toHaveBeenCalled();
     expect(saveLastDir).toHaveBeenCalled();
     expect(order).toEqual(["save", "import"]);
-    console.log('✔ END   test: uses showOpenFilePicker when available');
+    console.log('✔ END:   uses showOpenFilePicker when available');
   });
 
   it("uses showOpenFilePicker for folders", async () => {
-    console.log('▶ START test: uses showOpenFilePicker for folders');
+    console.log('▶ START: uses showOpenFilePicker for folders');
     const handles = [
       {
         kind: "file",
@@ -116,7 +116,7 @@ describe("import pickers", () => {
       expect.anything(),
     );
     expect(saveLastDir).toHaveBeenCalledWith(handles[0], expect.anything());
-    console.log('✔ END   test: uses showOpenFilePicker for folders');
+    console.log('✔ END:   uses showOpenFilePicker for folders');
   });
 });
 

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+# Banner for PR 163
+echo "────────────────────────────────────────────────────────────"
+echo "🔧  Sober-Body Dev Script – changes for PR #163"
+echo "────────────────────────────────────────────────────────────"
 # Idempotent dev helper for Sober-Body & PronunCo.
 #
 # Flags:
@@ -36,6 +40,8 @@ done
 
 # Export exact string "true" when handle tracing is requested
 DEBUG_HANDLES=${debug_handles:+true}
+echo "DEBUG_HANDLES flag (bash bool) = $debug_handles"
+echo "DEBUG_HANDLES exported string  = ${DEBUG_HANDLES:-''}"
 
 #─── helpers ──────────────────────────────────────────────────────────────
 edge () {
@@ -83,9 +89,11 @@ if $run_tests; then
   # Sober-Body app
   echo "— apps/sober-body —"
   time pnpm test:unit:sb -- --reporter=verbose
+  echo "✅ Vitest finished apps/sober-body with exit code $?"
 
   # PronunCo app
   echo -e "\n— apps/pronunco —"
+  echo "⏳ Launching PronunCo tests … Vitest should be idle now"
   (
     DEBUG_HANDLES=$DEBUG_HANDLES \
     time timeout 600 \


### PR DESCRIPTION
## Summary
- add a banner and flag details in `scripts/dev.sh`
- log vitest exit status
- message before PronunCo tests
- mark start and end of each PronunCo unit test

## Testing
- `bash scripts/dev.sh -t --debug-handles` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c56b41cf0832b9be8371563858ef2