### PR TITLE
Add debug logs for PronunCo handle tracing

### DIFF
--- a/apps/pronunco/__tests__/import-picker.test.tsx
+++ b/apps/pronunco/__tests__/import-picker.test.tsx
@@ -1,3 +1,5 @@
+// 🔎 sanity-check
+console.log('>>>> import-picker file evaluated. DEBUG_HANDLES =', process.env.DEBUG_HANDLES);
 import { superTraceOpenHandles } from '../tests/helpers/super-trace-open-handles';
 superTraceOpenHandles();
 

--- a/apps/pronunco/tests/helpers/super-trace-open-handles.ts
+++ b/apps/pronunco/tests/helpers/super-trace-open-handles.ts
@@ -1,4 +1,5 @@
 import { afterAll, beforeAll } from 'vitest';
+console.log('++++ superTrace helper loaded, DEBUG_HANDLES=', process.env.DEBUG_HANDLES);
 
 /**
  * Streams:


### PR DESCRIPTION
## Summary
- add console output to confirm `superTraceOpenHandles` helper is imported
- add guard log when helper module is loaded

## Testing
- `pnpm -r lint`
- `DEBUG_HANDLES=true pnpm exec vitest run __tests__/import-picker.test.tsx --reporter=verbose` *(fails: Command timed out)*
- `pnpm run test:unit:pc` *(hangs; killed)*

------
https://chatgpt.com/codex/tasks/task_e_686c62c60c1c832b9b1ff342c293073c