### PR TITLE
Fix tracer import in tests

### DIFF
--- a/apps/pronunco/__tests__/import-picker.test.tsx
+++ b/apps/pronunco/__tests__/import-picker.test.tsx
@@ -1,7 +1,4 @@
-// 🔎 sanity-check
-console.log('>>>> import-picker file evaluated. DEBUG_HANDLES =', process.env.DEBUG_HANDLES);
-import { superTraceOpenHandles } from '../tests/helpers/super-trace-open-handles';
-superTraceOpenHandles();
+import '../tests/helpers/super-trace-open-handles';
 
 import React from "react";
 import { render, screen, fireEvent } from "@testing-library/react";

--- a/apps/pronunco/tests/helpers/super-trace-open-handles.ts
+++ b/apps/pronunco/tests/helpers/super-trace-open-handles.ts
@@ -1,5 +1,7 @@
 import { afterAll, beforeAll } from 'vitest';
-console.log('++++ superTrace helper loaded, DEBUG_HANDLES=', process.env.DEBUG_HANDLES);
+
+// ── Side-effect tracer: runs automatically when file is imported ──
+if (process.env.DEBUG_HANDLES === 'true') {
 
 /**
  * Streams:
@@ -7,10 +9,6 @@ console.log('++++ superTrace helper loaded, DEBUG_HANDLES=', process.env.DEBUG_H
  * • a full handle dump via wtfnode every 3 s.
  * Automatically disabled unless DEBUG_HANDLES=true.
  */
-export function superTraceOpenHandles() {
-  if (process.env.DEBUG_HANDLES !== 'true') return;
-
-  // Light ticker
   const tick = setInterval(() => {
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore private API


### PR DESCRIPTION
## Summary
- run super-trace helper automatically on import
- update ImportPicker test to import tracer as side effect
- drop temporary console logs

## Testing
- `pnpm vitest run -c apps/pronunco/vitest.config.ts --reporter=dot` *(fails: Vitest did not finish)*

------
https://chatgpt.com/codex/tasks/task_e_686c6ec74954832baa97107858d7484d