### PR TITLE
Fix test mocks and cleanup

### DIFF
--- a/apps/pronunco/__tests__/clear-decks.test.tsx
+++ b/apps/pronunco/__tests__/clear-decks.test.tsx
@@ -4,7 +4,7 @@ import userEvent from '@testing-library/user-event'
 import { describe, it, expect } from 'vitest'
 import { vi } from 'vitest'
 
-let clearMock: any
+var clearMock: any
 vi.mock('../src/db', () => {
   clearMock = vi.fn()
   return { clearDecks: clearMock, db: {} }

--- a/apps/pronunco/__tests__/coach-page.test.tsx
+++ b/apps/pronunco/__tests__/coach-page.test.tsx
@@ -24,7 +24,8 @@ describe('CoachPage', () => {
         </SettingsProvider>
       </MemoryRouter>
     )
-    expect(await screen.findByText(/hello/i)).toBeInTheDocument()
+    const heading = await screen.findByRole('heading', { name: /hello/i })
+    expect(heading).toBeInTheDocument()
     console.log('✔ END:   renders first prompt line');
   })
 })

--- a/apps/pronunco/tests/setup-vitest.ts
+++ b/apps/pronunco/tests/setup-vitest.ts
@@ -1,6 +1,7 @@
 import 'fake-indexeddb/auto';
 import Dexie from 'dexie';
 import { afterEach, vi } from 'vitest';
+import { cleanup } from '@testing-library/react';
 
 // close & delete every dexie DB opened during a test file
 afterEach(async () => {
@@ -13,6 +14,7 @@ afterEach(async () => {
       indexedDB.deleteDatabase(name);
     }),
   );
+  cleanup();
 });
 
 // reset timers and mocks so leaks don't accumulate across suites


### PR DESCRIPTION
## Summary
- fix hoisted mock usage in clear-decks test
- query heading in coach-page test
- ensure cleanup after each vitest

## Testing
- `pnpm test:unit:pc` *(fails: Unable to find role="button" and name `/clear decks/i`)*

------
https://chatgpt.com/codex/tasks/task_e_686ca66a2110832b8e6b9ce9e6db799a