### PR TITLE
feat(pronunco): embed deck context

### DIFF
--- a/apps/pronunco/__tests__/coach-page.test.tsx
+++ b/apps/pronunco/__tests__/coach-page.test.tsx
@@ -1,14 +1,12 @@
-import React from 'react'
-import { render, screen } from '@testing-library/react'
-import { MemoryRouter, Routes, Route } from 'react-router-dom'
-import { describe, it, expect } from 'vitest'
-import CoachPage from '../src/pages/CoachPage'
-import { DeckContext } from '../../sober-body/src/features/games/deck-context'
-import { SettingsProvider } from '../../sober-body/src/features/core/settings-context'
-import { vi } from 'vitest'
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { describe, it, expect, vi } from 'vitest';
+import CoachPage from '../src/pages/CoachPage';
+import { DeckContext } from '../src/features/deck-context';
+import { SettingsProvider } from '../src/features/core/settings-context';
 
-
-const deck = { id: 'd1', title: 'D1', lang: 'en', lines: ['hello', 'bye'], tags: [], updated: 0 }
+const deck = { id: 'd1', title: 'D1', lang: 'en', lines: ['hello', 'bye'], tags: [], updated: 0 };
 
 describe('CoachPage', () => {
   it('renders first prompt line', async () => {
@@ -23,8 +21,8 @@ describe('CoachPage', () => {
           </DeckContext.Provider>
         </SettingsProvider>
       </MemoryRouter>
-    )
-    expect(document.body.innerHTML).toContain('hello')
+    );
+    expect(document.body.innerHTML).toContain('hello');
     console.log('✔ END:   renders first prompt line');
-  })
-})
+  });
+});

--- a/apps/pronunco/__tests__/language-filter.test.ts
+++ b/apps/pronunco/__tests__/language-filter.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { getLanguages } from '../../../apps/sober-body/src/features/games/get-languages';
-import type { Deck } from '../../../apps/sober-body/src/features/games/deck-types';
+import { getLanguages } from '../src/features/get-languages';
+import type { Deck } from '../src/types';
 
 describe('language filter', () => {
   it('gets unique sorted languages', () => {

--- a/apps/pronunco/__tests__/settings-context.test.tsx
+++ b/apps/pronunco/__tests__/settings-context.test.tsx
@@ -1,6 +1,6 @@
 import { renderHook, act } from '@testing-library/react';
 import { describe, it, expect } from 'vitest';
-import { SettingsProvider, useSettings } from '../../../apps/sober-body/src/features/core/settings-context';
+import { SettingsProvider, useSettings } from '../src/features/core/settings-context';
 
 describe('settings context', () => {
   it('updates language in settings context', () => {

--- a/apps/pronunco/package.json
+++ b/apps/pronunco/package.json
@@ -13,7 +13,8 @@
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router-dom": "^6.30.1",
-    "coach-ui": "workspace:*"
+    "coach-ui": "workspace:*",
+    "idb-keyval": "^6.2.2"
   },
   "devDependencies": {
     "@testing-library/react": "^16.3.0",

--- a/apps/pronunco/src/components/DrillLink.tsx
+++ b/apps/pronunco/src/components/DrillLink.tsx
@@ -1,5 +1,5 @@
 import { Link } from 'react-router-dom';
-import type { Deck } from '../../../../apps/sober-body/src/features/games/deck-types';
+import type { Deck } from '../types';
 
 export default function DrillLink({ deck }: { deck: Deck }) {
   return (

--- a/apps/pronunco/src/features/core/bac.ts
+++ b/apps/pronunco/src/features/core/bac.ts
@@ -1,0 +1,114 @@
+// src/features/core/bac.ts
+//---------------------------------------------------------------
+// Minimal Widmark-based BAC engine (MVP stub)
+// • All math stays in *this* module so we can swap to Rust/WASM
+//   later without touching React code.
+//---------------------------------------------------------------
+
+/** Default Widmark r‐values (total body-water constant) */
+const R_CONST = {
+  m: 0.68, // sex assigned male at birth
+  f: 0.55  // sex assigned female at birth
+};
+
+/** Default ethanol elimination rate (%BAC per hour) */
+export const DEFAULT_BETA = 0.015;
+
+/** Density of pure ethanol (g/mL) */
+const ETHANOL_DENSITY = 0.789;
+
+/* ------------------------------------------------------------------ */
+/* Types                                                              */
+/* ------------------------------------------------------------------ */
+
+export interface Physiology {
+  weightKg: number;
+  sex: "m" | "f";
+  /** optional personalised R value (else fallback by sex) */
+  r?: number;
+  /** optional personalised elimination rate β */
+  beta?: number;
+}
+
+export interface DrinkEvent {
+  /** volume consumed in millilitres (e.g. 330-ml beer) */
+  volumeMl: number;
+  /** alcohol by volume as a fraction (e.g. 0.05 for 5 %) */
+  abv: number;
+  /** timestamp when the drink was finished */
+  date: Date;
+}
+
+/* ------------------------------------------------------------------ */
+/* Core helpers                                                       */
+/* ------------------------------------------------------------------ */
+
+/** grams of pure ethanol in a drink */
+export function gramsFromDrink(d: DrinkEvent): number {
+  return d.volumeMl * d.abv * ETHANOL_DENSITY;
+}
+
+/** Widmark single-point BAC estimate for one drink after a
+ *  specified time interval */
+export function widmark(
+  grams: number,
+  physiology: Physiology,
+  hoursSinceDrink: number
+): number {
+  const r = physiology.r ?? R_CONST[physiology.sex];
+  const beta = physiology.beta ?? DEFAULT_BETA;
+
+  const raw = (grams / (physiology.weightKg * 1000 * r)) * 100; // %BAC
+  const adjusted = raw - beta * hoursSinceDrink;
+  return Math.max(adjusted, 0);
+}
+
+/** Aggregate BAC for an array of drinks at a given time (default = now) */
+export function estimateBAC(
+  drinks: DrinkEvent[],
+  physiology: Physiology,
+  at: Date = new Date()
+): number {
+  if (drinks.length === 0) return 0;
+
+  const beta = physiology.beta ?? DEFAULT_BETA;
+  const r = physiology.r ?? R_CONST[physiology.sex];
+
+  const sorted = [...drinks]
+    .filter(d => d.date.getTime() <= at.getTime())
+    .sort((a, b) => a.date.getTime() - b.date.getTime());
+
+  if (sorted.length === 0) return 0;
+
+  let bac = 0;
+  let last = sorted[0].date;
+
+  for (const d of sorted) {
+    let gap = (d.date.getTime() - last.getTime()) / (1000 * 60 * 60);
+    if (gap < 0) gap = 0;
+    bac = Math.max(bac - beta * gap, 0);
+
+    const raw = (gramsFromDrink(d) / (physiology.weightKg * 1000 * r)) * 100;
+    bac += raw;
+
+    last = d.date;
+  }
+
+  let finalGap = (at.getTime() - last.getTime()) / (1000 * 60 * 60);
+  if (finalGap < 0) finalGap = 0;
+  bac = Math.max(bac - beta * finalGap, 0);
+
+  return bac;
+}
+
+/** Hours until BAC reaches targetBAC (default 0.000 %) */
+export function hoursToSober(
+  currentBAC: number,
+  physiology: Physiology,
+  targetBAC = 0
+): number {
+  const beta = physiology.beta ?? DEFAULT_BETA;
+  if (currentBAC <= targetBAC) return 0;
+  return (currentBAC - targetBAC) / beta;
+}
+

--- a/apps/pronunco/src/features/core/settings-context.tsx
+++ b/apps/pronunco/src/features/core/settings-context.tsx
@@ -1,0 +1,42 @@
+/* eslint-disable react-refresh/only-export-components */
+import React, { createContext, useContext, useEffect, useRef, useState } from 'react'
+import { loadSettings, saveSettings, type Settings } from './storage'
+import { DEFAULT_BETA } from './bac'
+export interface SettingsValue {
+  settings: Required<Settings>
+  setSettings: React.Dispatch<React.SetStateAction<Required<Settings>>>
+}
+const DEFAULTS: Required<Settings> = {
+  weightKg: 70,
+  sex: 'm',
+  beta: DEFAULT_BETA,
+  nativeLang: 'en',
+  locale: 'en',
+  slowSpeech: false
+}
+const SettingsContext = createContext<SettingsValue | undefined>(undefined)
+export function SettingsProvider({ children }: { children: React.ReactNode }) {
+  const [settings, setSettings] = useState<Required<Settings>>(DEFAULTS)
+  const loaded = useRef(false)
+  useEffect(() => {
+    loadSettings().then(stored => {
+      if (stored) setSettings(prev => ({ ...prev, ...stored }))
+      loaded.current = true
+    })
+  }, [])
+  useEffect(() => {
+    if (loaded.current) {
+      saveSettings(settings)
+    }
+  }, [settings])
+  return (
+    <SettingsContext.Provider value={{ settings, setSettings }}>
+      {children}
+    </SettingsContext.Provider>
+  )
+}
+export function useSettings() {
+  const ctx = useContext(SettingsContext)
+  if (!ctx) throw new Error('useSettings must be used within SettingsProvider')
+  return ctx
+}

--- a/apps/pronunco/src/features/core/storage.ts
+++ b/apps/pronunco/src/features/core/storage.ts
@@ -1,0 +1,29 @@
+import { get, set } from 'idb-keyval'
+import { type DrinkEvent } from './bac'
+
+export const KEYS = { drinks: 'sb_drinks', settings: 'sb_settings' } as const
+
+export async function loadDrinks(): Promise<DrinkEvent[]> {
+  return (await get(KEYS.drinks)) ?? []
+}
+
+export async function saveDrinks(arr: DrinkEvent[]): Promise<void> {
+  await set(KEYS.drinks, arr)
+}
+
+export interface Settings {
+  weightKg?: number
+  sex?: 'm' | 'f'
+  beta?: number
+  nativeLang?: string
+  locale?: string
+  slowSpeech?: boolean
+}
+
+export async function loadSettings(): Promise<Settings | undefined> {
+  return (await get(KEYS.settings)) ?? undefined
+}
+
+export async function saveSettings(obj: Settings): Promise<void> {
+  await set(KEYS.settings, obj)
+}

--- a/apps/pronunco/src/features/deck-context.tsx
+++ b/apps/pronunco/src/features/deck-context.tsx
@@ -1,27 +1,27 @@
-import React, { useContext, useEffect, useRef, useState } from 'react'
-import { db } from '../db'
-import type { Deck } from '../../../../apps/sober-body/src/features/games/deck-types'
-import { DeckContext } from '../../../../apps/sober-body/src/features/games/deck-context'
+import React, { createContext, useContext, useEffect, useRef, useState } from 'react';
+import { db } from '../db';
+import type { Deck } from '../types';
 
 export interface DeckValue {
-  decks: Deck[]
-  activeDeck: string | null
-  setActiveDeck: (id: string) => void
+  decks: Deck[];
+  activeDeck: string | null;
+  setActiveDeck: (id: string) => void;
 }
 
+export const DeckContext = createContext<DeckValue | undefined>(undefined);
 
 export function DeckProvider({ children }: { children: React.ReactNode }) {
-  const [decks, setDecks] = useState<Deck[]>([])
-  const [activeDeck, setActiveDeck] = useState<string | null>(null)
-  const loaded = useRef(false)
+  const [decks, setDecks] = useState<Deck[]>([]);
+  const [activeDeck, setActiveDeck] = useState<string | null>(null);
+  const loaded = useRef(false);
 
   useEffect(() => {
-    let alive = true
+    let alive = true;
     const load = async () => {
-      const rows = await db.decks.toArray()
-      const arr: Deck[] = []
+      const rows = await db.decks.toArray();
+      const arr: Deck[] = [];
       for (const r of rows) {
-        const cards = await db.cards.where('deckId').equals(r.id).toArray()
+        const cards = await db.cards.where('deckId').equals(r.id).toArray();
         arr.push({
           id: r.id,
           title: r.title,
@@ -29,33 +29,33 @@ export function DeckProvider({ children }: { children: React.ReactNode }) {
           lines: cards.map(c => c.text),
           tags: Array.isArray(r.tags) ? (r.tags as string[]) : [],
           updated: r.updatedAt,
-        })
+        });
       }
       if (alive) {
-        setDecks(arr)
-        loaded.current = true
+        setDecks(arr);
+        loaded.current = true;
       }
-    }
-    load()
+    };
+    void load();
     return () => {
-      alive = false
-    }
-  }, [])
+      alive = false;
+    };
+  }, []);
 
   return (
     <DeckContext.Provider value={{ decks, activeDeck, setActiveDeck }}>
       {children}
     </DeckContext.Provider>
-  )
+  );
 }
 
 export function useDecks() {
-  const ctx = useContext(DeckContext)
-  if (!ctx) throw new Error('useDecks must be used within DeckProvider')
-  return ctx
+  const ctx = useContext(DeckContext);
+  if (!ctx) throw new Error('useDecks must be used within DeckProvider');
+  return ctx;
 }
 
 export function useDeck(id: string) {
-  const { decks } = useDecks()
-  return decks.find(d => d.id === id)
+  const { decks } = useDecks();
+  return decks.find(d => d.id === id);
 }

--- a/apps/pronunco/src/features/get-languages.ts
+++ b/apps/pronunco/src/features/get-languages.ts
@@ -1,0 +1,5 @@
+export function getLanguages(decks: import('./deck-types').Deck[]): string[] {
+  const set = new Set<string>()
+  decks.forEach(d => set.add(d.lang))
+  return Array.from(set).sort()
+}

--- a/apps/pronunco/src/main.tsx
+++ b/apps/pronunco/src/main.tsx
@@ -1,8 +1,8 @@
-import { StrictMode } from 'react'
-import { createRoot } from 'react-dom/client'
-import App from './App'
-import { SettingsProvider } from '../../../../apps/sober-body/src/features/core/settings-context'
-import { DeckProvider } from './features/deck-context'
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import App from './App';
+import { SettingsProvider } from './features/core/settings-context';
+import { DeckProvider } from './features/deck-context';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
@@ -12,4 +12,4 @@ createRoot(document.getElementById('root')!).render(
       </DeckProvider>
     </SettingsProvider>
   </StrictMode>
-)
+);

--- a/apps/pronunco/src/types.ts
+++ b/apps/pronunco/src/types.ts
@@ -1,0 +1,15 @@
+export interface Sig {
+  signer: string;           // e.g. "Sober-Body"
+  alg: 'ed25519';
+  value: string;            // base64
+}
+
+export interface Deck {
+  id: string;
+  title: string;
+  lang: string;             // BCP-47
+  lines: string[];
+  tags?: string[];
+  sig?: Sig;
+  updated?: number;
+}

--- a/apps/pronunco/tsconfig.json
+++ b/apps/pronunco/tsconfig.json
@@ -6,7 +6,11 @@
     "jsx": "react-jsx",
     "strict": true,
     "skipLibCheck": true,
-    "noEmit": true
+    "noEmit": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    }
   },
   "include": ["src", "test", "__tests__"]
 }

--- a/apps/pronunco/vite.config.ts
+++ b/apps/pronunco/vite.config.ts
@@ -1,6 +1,6 @@
 import { defineConfig, loadEnv } from 'vite'
 import react from '@vitejs/plugin-react'
-import { join } from 'path'
+import { join, resolve } from 'path'
 
 export default defineConfig(({ mode }) => {
   const envDir = join(__dirname, '../../')
@@ -13,6 +13,7 @@ export default defineConfig(({ mode }) => {
     base: '/pc/',
     envDir,
     plugins: [react()],
+    resolve: { alias: { '@': resolve(__dirname, 'src') } },
     server: { port: 5174 },
     test: { environment: 'jsdom' }
   }


### PR DESCRIPTION
## Summary
- remove imports that reached into `apps/sober-body`
- copy Settings context helpers into PronunCo app
- implement local deck context and helper types
- configure alias `@/*` for PronunCo sources
- wire Vite config to resolve `@`
- update tests and code to use local modules

## Testing
- `pnpm test:unit:pc` *(fails: useDecks must be used within DeckProvider)*

------
https://chatgpt.com/codex/tasks/task_e_686cb78b581c832b96c536cabd159bdb