### PR TITLE
Implement minimal deck stub

### DIFF
--- a/apps/pronunco/__tests__/coach-page.test.tsx
+++ b/apps/pronunco/__tests__/coach-page.test.tsx
@@ -3,17 +3,16 @@ import { render, screen } from '@testing-library/react';
 import { MemoryRouter, Routes, Route } from 'react-router-dom';
 import { describe, it, expect, vi } from 'vitest';
 import CoachPage from '../src/pages/CoachPage';
-import { DeckContext } from '../src/features/deck-context';
+import { DeckProvider } from '../src/features/deck-context';
 import { SettingsProvider } from '../src/features/core/settings-context';
 
 vi.mock('../../../apps/sober-body/src/features/games/deck-context', async () =>
-  await vi.importActual('../src/features/deck-context')
+  await import('../src/features/deck-context')
 );
 vi.mock('../../../apps/sober-body/src/features/core/settings-context', async () =>
-  await vi.importActual('../src/features/core/settings-context')
+  await import('../src/features/core/settings-context')
 );
 
-const deck = { id: 'd1', title: 'D1', lang: 'en', lines: ['hello', 'bye'], tags: [], updated: 0 };
 
 describe('CoachPage', () => {
   it('renders first prompt line', async () => {
@@ -21,15 +20,15 @@ describe('CoachPage', () => {
     render(
       <MemoryRouter initialEntries={['/coach/d1']}>
         <SettingsProvider>
-          <DeckContext.Provider value={{ decks: [deck], activeDeck: deck.id, setActiveDeck: vi.fn() }}>
+          <DeckProvider deckId="d1">
             <Routes>
               <Route path="/coach/:deckId" element={<CoachPage />} />
             </Routes>
-          </DeckContext.Provider>
+          </DeckProvider>
         </SettingsProvider>
       </MemoryRouter>
     );
-    expect(document.body.innerHTML).toContain('hello');
+    expect(document.body.innerHTML).toContain('Hola');
     console.log('✔ END:   renders first prompt line');
   });
 });

--- a/apps/pronunco/src/features/deck-context.tsx
+++ b/apps/pronunco/src/features/deck-context.tsx
@@ -1,12 +1,61 @@
-import { createContext, useContext } from "react";
+import { createContext, useContext, useState } from "react";
 
-// Temporary stub – just enough for CoachPage to mount.
-export const DeckContext = createContext<any>(null);
+type Card = { front: string; back: string };
+type Deck = { id: string; title: string; cards: Card[]; lines?: string[] };
 
-export const DeckProvider = ({ children }: { children: React.ReactNode }) => (
-  <DeckContext.Provider value={{}}>{children}</DeckContext.Provider>
-);
+type DeckCtx = {
+  deck: Deck;
+  current: number;
+  next(): void;
+  prev(): void;
+  speak(text: string): void;
+  listen(cb: (text: string) => void): void;
+};
 
-export const useDeck = () => useContext(DeckContext);
+export const DeckContext = createContext<DeckCtx | null>(null);
 
-export const useDecks = () => useContext(DeckContext);
+export function DeckProvider({
+  deckId,
+  children,
+}: {
+  deckId: string;
+  children: React.ReactNode;
+}) {
+  const dummy: Deck = {
+    id: deckId,
+    title: "Dummy deck",
+    cards: [
+      { front: "Hola", back: "Hello" },
+      { front: "Adiós", back: "Good-bye" },
+    ],
+    lines: ["Hola", "Adiós"],
+  };
+
+  const [idx, setIdx] = useState(0);
+
+  const value: DeckCtx = {
+    deck: dummy,
+    current: idx,
+    next: () => setIdx((i) => (i + 1) % dummy.cards.length),
+    prev: () => setIdx((i) => (i - 1 + dummy.cards.length) % dummy.cards.length),
+    speak: () => {
+      /* no-op */
+    },
+    listen: () => {
+      /* no-op */
+    },
+  };
+
+  return <DeckContext.Provider value={value}>{children}</DeckContext.Provider>;
+}
+
+export function useDeck() {
+  const ctx = useContext(DeckContext);
+  if (!ctx) throw new Error("useDeck must be inside DeckProvider");
+  return ctx;
+}
+
+export function useDecks() {
+  const ctx = useDeck();
+  return { decks: [ctx.deck], activeDeck: ctx.deck.id, setActiveDeck: () => {} };
+}

--- a/apps/pronunco/src/main.tsx
+++ b/apps/pronunco/src/main.tsx
@@ -7,7 +7,7 @@ import { DeckProvider } from './features/deck-context';
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <SettingsProvider>
-      <DeckProvider>
+      <DeckProvider deckId="demo">
         <App />
       </DeckProvider>
     </SettingsProvider>


### PR DESCRIPTION
## Summary
- set up minimal DeckContext for CoachPage with dummy deck
- default to demo deck in client entry
- update failing test for new DeckContext design

## Testing
- `pnpm --filter ./apps/pronunco test`
- `pnpm --filter ./apps/sober-body test`


------
https://chatgpt.com/codex/tasks/task_e_686d4b1349b4832ba68a544810fb535c