### PR TITLE
Fix coach navigation path

### DIFF
--- a/apps/pronunco/__tests__/deck-manager.navigate.test.tsx
+++ b/apps/pronunco/__tests__/deck-manager.navigate.test.tsx
@@ -25,7 +25,7 @@ describe('DeckManager drill button', () => {
         <DeckManager />
       </MemoryRouter>
     )
-    expect(document.body.innerHTML).toContain('/coach')
+    expect(document.body.innerHTML).toContain('/pc/coach')
     console.log('✔ END:   navigates to coach route');
   })
 })

--- a/apps/pronunco/src/components/DeckManager.tsx
+++ b/apps/pronunco/src/components/DeckManager.tsx
@@ -146,7 +146,7 @@ export default function DeckManager() {
 
   const onDrill = () => {
     const id = [...selectedIds][0];
-    if (id) navigate(`/coach/${id}`);
+    if (id) navigate(`/pc/coach/${id}`);
   };
 
   const onExport = async () => {
@@ -224,7 +224,7 @@ export default function DeckManager() {
               <td>{d.title}</td>
               <td>{d.lang}</td>
               <td className="text-center">
-                <Link to={`/coach/${d.id}`} aria-label="Drill deck">
+                <Link to={`/pc/coach/${d.id}`} aria-label="Drill deck">
                   ▶
                 </Link>
               </td>


### PR DESCRIPTION
## Summary
- update DeckManager drill action and link to navigate to `/pc/coach/:id`
- adjust navigate test for new path

## Testing
- `pnpm test:unit:pc`

------
https://chatgpt.com/codex/tasks/task_e_686de7ce1d98832b993266a2c72f166c