### PR TITLE
Fix coach route path

### DIFF
--- a/apps/pronunco/__tests__/deck-manager.navigate.test.tsx
+++ b/apps/pronunco/__tests__/deck-manager.navigate.test.tsx
@@ -25,7 +25,7 @@ describe('DeckManager drill button', () => {
         <DeckManager />
       </MemoryRouter>
     )
-    expect(document.body.innerHTML).toContain('/pc/coach')
+    expect(document.body.innerHTML).toContain('/coach')
     console.log('✔ END:   navigates to coach route');
   })
 })

--- a/apps/pronunco/src/App.tsx
+++ b/apps/pronunco/src/App.tsx
@@ -8,7 +8,8 @@ export default function App() {
       <Routes>
         <Route path="/" element={<Navigate to="/decks" replace />} />
         <Route path="/decks" element={<DeckManager />} />
-        <Route path="/coach/:deckId" element={<CoachPage />} />
+        <Route path="coach/:deckId" element={<CoachPage />} />
+        <Route path="*" element={<Navigate to="decks" />} />
       </Routes>
     </BrowserRouter>
   )

--- a/apps/pronunco/src/components/DeckManager.tsx
+++ b/apps/pronunco/src/components/DeckManager.tsx
@@ -146,7 +146,7 @@ export default function DeckManager() {
 
   const onDrill = () => {
     const id = [...selectedIds][0];
-    if (id) navigate(`/pc/coach/${id}`);
+    if (id) navigate(`../coach/${id}`);
   };
 
   const onExport = async () => {
@@ -224,7 +224,7 @@ export default function DeckManager() {
               <td>{d.title}</td>
               <td>{d.lang}</td>
               <td className="text-center">
-                <Link to={`/pc/coach/${d.id}`} aria-label="Drill deck">
+                <Link to={`../coach/${d.id}`} aria-label="Drill deck">
                   ▶
                 </Link>
               </td>


### PR DESCRIPTION
## Summary
- update PronunCo router to mount coach page without leading slash
- update DeckManager links to use relative `../coach/<id>` paths
- adjust navigation unit test to expect `/coach`

## Testing
- `pnpm -r lint`
- `pnpm -r test`


------
https://chatgpt.com/codex/tasks/task_e_686df25f379c832b9d99de90bd6f65ea