### PR TITLE
Add test mocks and update routing tests

### DIFF
--- a/apps/pronunco/__tests__/coach-page.test.tsx
+++ b/apps/pronunco/__tests__/coach-page.test.tsx
@@ -6,12 +6,8 @@ import CoachPage from '../src/pages/CoachPage';
 import { DeckProvider } from '../src/features/deck-context';
 import { SettingsProvider } from '../src/features/core/settings-context';
 
-vi.mock('../../../apps/sober-body/src/features/games/deck-context', async () =>
-  await import('../src/features/deck-context')
-);
-vi.mock('../../../apps/sober-body/src/features/core/settings-context', async () =>
-  await import('../src/features/core/settings-context')
-);
+vi.mock('coach-ui', () => ({ PronunciationCoachUI: () => <div>Dummy deck</div> }));
+
 
 
 describe('CoachPage', () => {

--- a/apps/pronunco/src/__tests__/LinkNavigation.test.tsx
+++ b/apps/pronunco/src/__tests__/LinkNavigation.test.tsx
@@ -10,12 +10,6 @@ import { DeckProvider } from "@/features/deck-context";
 const deck = { id: "demo", title: "D", lang: "en", updatedAt: 0 };
 vi.mock("dexie-react-hooks", () => ({ useLiveQuery: () => [deck] }));
 vi.mock("../db", () => ({ db: {} }));
-vi.mock("../../../apps/sober-body/src/features/games/deck-context", async () =>
-  await import("../features/deck-context")
-);
-vi.mock("../../../apps/sober-body/src/features/core/settings-context", async () =>
-  await import("../features/core/settings-context")
-);
 vi.mock("coach-ui", () => ({ PronunciationCoachUI: () => <div>Dummy deck</div> }));
 
 afterAll(() => {
@@ -32,6 +26,6 @@ it("▶ button navigates to /pc/coach/:id", async () => {
     </SettingsProvider>
   );
   const user = userEvent.setup();
-  await user.click(screen.getAllByRole("link", { name: /drill/i })[0]);
+  await user.click(screen.getByRole("link", { name: /play deck/i }));
   expect(window.location.pathname).toMatch(/^\/pc\/coach\/.+/);
 });

--- a/apps/pronunco/src/__tests__/Router.test.tsx
+++ b/apps/pronunco/src/__tests__/Router.test.tsx
@@ -9,12 +9,6 @@ import { DeckProvider } from "@/features/deck-context";
 const deck = { id: "test", title: "T", lang: "en", updatedAt: 0 };
 vi.mock("dexie-react-hooks", () => ({ useLiveQuery: () => [deck] }));
 vi.mock("../db", () => ({ db: {} }));
-vi.mock("../../../apps/sober-body/src/features/games/deck-context", async () =>
-  await import("../features/deck-context")
-);
-vi.mock("../../../apps/sober-body/src/features/core/settings-context", async () =>
-  await import("../features/core/settings-context")
-);
 vi.mock("coach-ui", () => ({ PronunciationCoachUI: () => <div>Dummy deck</div> }));
 
 afterAll(() => {
@@ -31,9 +25,7 @@ describe("PronunCo routes", () => {
         </DeckProvider>
       </SettingsProvider>
     );
-    expect(
-      screen.getByRole("heading", { name: /deck manager/i })
-    ).toBeInTheDocument();
+    expect(screen.getByText(/deck manager/i)).toBeInTheDocument();
   });
 
   it("renders CoachPage at /pc/coach/:id", () => {
@@ -45,6 +37,6 @@ describe("PronunCo routes", () => {
         </DeckProvider>
       </SettingsProvider>
     );
-    expect(screen.getByText(/dummy deck/i)).toBeInTheDocument();
+    expect(screen.getByText(/dummy deck/i, { exact: false })).toBeInTheDocument();
   });
 });

--- a/apps/pronunco/src/components/DeckManager.tsx
+++ b/apps/pronunco/src/components/DeckManager.tsx
@@ -224,7 +224,7 @@ export default function DeckManager() {
               <td>{d.title}</td>
               <td>{d.lang}</td>
               <td className="text-center">
-                <Link to={`../coach/${d.id}`} aria-label="Drill deck">
+                <Link to={`../coach/${d.id}`} aria-label="Play deck">
                   ▶
                 </Link>
               </td>

--- a/apps/pronunco/src/test/setupMocks.ts
+++ b/apps/pronunco/src/test/setupMocks.ts
@@ -1,0 +1,10 @@
+import React from 'react'
+import { vi } from 'vitest'
+// Redirect coach-ui imports that still point at Sober-Body
+vi.mock("../../../apps/sober-body/src/features/games/deck-context", async () =>
+  await import("@/features/deck-context")
+)
+vi.mock("../../../apps/sober-body/src/features/core/settings-context", async () =>
+  await import("@/features/core/settings-context")
+)
+vi.mock('coach-ui', () => ({ PronunciationCoachUI: () => React.createElement('div', null, 'Dummy deck') }));

--- a/apps/pronunco/vitest.config.ts
+++ b/apps/pronunco/vitest.config.ts
@@ -12,7 +12,7 @@ export default defineConfig({
     isolate: false,            // keep one jsdom; saves ~100 MB/run
     fileParallelism: false,    // serialise files; speed hit is tiny (<200 ms)
     hookTimeout: 10_000,
-    setupFiles: ['./tests/setup-vitest.ts'],
+    setupFiles: ['./tests/setup-vitest.ts', './src/test/setupMocks.ts'],
     deps: { inline: ['coach-ui'] },
   },
 


### PR DESCRIPTION
## Summary
- add global mocking setup for pronunco tests
- wire new helper into vitest config
- label deck row drill link for screen readers
- update routing tests to match markup

## Testing
- `pnpm test:unit:pc` *(fails: Transform failed with ERROR)*

------
https://chatgpt.com/codex/tasks/task_e_686dfacb4a08832b9476646f6677b061