### PR TITLE
Fix mock path and update routing tests

### DIFF
--- a/apps/pronunco/src/__tests__/LinkNavigation.test.tsx
+++ b/apps/pronunco/src/__tests__/LinkNavigation.test.tsx
@@ -1,5 +1,5 @@
-/// <reference types="vitest" />
 // @vitest-environment jsdom
+/// <reference types="vitest" />
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { expect, it, vi, afterAll } from "vitest";
@@ -26,6 +26,6 @@ it("▶ button navigates to /pc/coach/:id", async () => {
     </SettingsProvider>
   );
   const user = userEvent.setup();
-  await user.click(screen.getByRole("link", { name: /play deck/i }));
+  await user.click(screen.getByRole("link", { name: /play/i }));
   expect(window.location.pathname).toMatch(/^\/pc\/coach\/.+/);
 });

--- a/apps/pronunco/src/__tests__/Router.test.tsx
+++ b/apps/pronunco/src/__tests__/Router.test.tsx
@@ -1,5 +1,5 @@
-/// <reference types="vitest" />
 // @vitest-environment jsdom
+/// <reference types="vitest" />
 import { render, screen } from "@testing-library/react";
 import { describe, it, expect, vi, afterAll } from "vitest";
 import App from "@/App";
@@ -25,10 +25,10 @@ describe("PronunCo routes", () => {
         </DeckProvider>
       </SettingsProvider>
     );
-    expect(screen.getByText(/deck manager/i)).toBeInTheDocument();
+    expect(screen.getByText(/deck manager \(beta\)/i)).toBeInTheDocument();
   });
 
-  it("renders CoachPage at /pc/coach/:id", () => {
+  it("renders CoachPage at /pc/coach/:id", async () => {
     window.history.pushState({}, "", "/pc/coach/test");
     render(
       <SettingsProvider>
@@ -37,6 +37,6 @@ describe("PronunCo routes", () => {
         </DeckProvider>
       </SettingsProvider>
     );
-    expect(screen.getByText(/dummy deck/i, { exact: false })).toBeInTheDocument();
+    expect(await screen.findByText(/dummy deck/i)).toBeInTheDocument();
   });
 });

--- a/apps/pronunco/src/test/setupMocks.ts
+++ b/apps/pronunco/src/test/setupMocks.ts
@@ -1,10 +1,10 @@
 import React from 'react'
 import { vi } from 'vitest'
 // Redirect coach-ui imports that still point at Sober-Body
-vi.mock("../../../apps/sober-body/src/features/games/deck-context", async () =>
+vi.mock("../../../../apps/sober-body/src/features/games/deck-context", async () =>
   await import("@/features/deck-context")
 )
-vi.mock("../../../apps/sober-body/src/features/core/settings-context", async () =>
-  await import("@/features/core/settings-context")
-)
+vi.mock("../../../../apps/sober-body/src/features/core/settings-context", () => ({
+  useSettings: () => ({ ttsEnabled: false, srEnabled: false }),
+}))
 vi.mock('coach-ui', () => ({ PronunciationCoachUI: () => React.createElement('div', null, 'Dummy deck') }));


### PR DESCRIPTION
## Summary
- adjust mock paths in `setupMocks.ts`
- refine Router and LinkNavigation tests
- ensure jsdom environment is specified at the top of tests

## Testing
- `pnpm test:unit:pc` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e6637fa50832b95afc71844ed8f28