### PR TITLE
Fix mock path and update routing tests

### DIFF
--- a/apps/pronunco/__tests__/coach-page.test.tsx
+++ b/apps/pronunco/__tests__/coach-page.test.tsx
@@ -2,17 +2,16 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { MemoryRouter, Routes, Route } from 'react-router-dom';
 import { describe, it, expect, vi } from 'vitest';
+vi.mock('coach-ui', () => ({ PronunciationCoachUI: () => <div>Dummy deck</div> }));
+
 import CoachPage from '../src/pages/CoachPage';
 import { DeckProvider } from '../src/features/deck-context';
 import { SettingsProvider } from '../src/features/core/settings-context';
-
-vi.mock('coach-ui', () => ({ PronunciationCoachUI: () => <div>Dummy deck</div> }));
 
 
 
 describe('CoachPage', () => {
   it('renders first prompt line', async () => {
-    console.log('▶ START: renders first prompt line');
     render(
       <MemoryRouter initialEntries={['/coach/d1']}>
         <SettingsProvider>
@@ -25,6 +24,5 @@ describe('CoachPage', () => {
       </MemoryRouter>
     );
     expect(document.body.innerHTML).toContain('Hola');
-    console.log('✔ END:   renders first prompt line');
   });
 });

--- a/apps/pronunco/src/__tests__/LinkNavigation.test.tsx
+++ b/apps/pronunco/src/__tests__/LinkNavigation.test.tsx
@@ -1,16 +1,17 @@
-/// <reference types="vitest" />
 // @vitest-environment jsdom
+/// <reference types="vitest" />
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { expect, it, vi, afterAll } from "vitest";
-import App from "@/App";
-import { SettingsProvider } from "@/features/core/settings-context";
-import { DeckProvider } from "@/features/deck-context";
 
 const deck = { id: "demo", title: "D", lang: "en", updatedAt: 0 };
 vi.mock("dexie-react-hooks", () => ({ useLiveQuery: () => [deck] }));
 vi.mock("../db", () => ({ db: {} }));
 vi.mock("coach-ui", () => ({ PronunciationCoachUI: () => <div>Dummy deck</div> }));
+
+import App from "@/App";
+import { SettingsProvider } from "@/features/core/settings-context";
+import { DeckProvider } from "@/features/deck-context";
 
 afterAll(() => {
   vi.unmock("coach-ui");
@@ -26,6 +27,6 @@ it("▶ button navigates to /pc/coach/:id", async () => {
     </SettingsProvider>
   );
   const user = userEvent.setup();
-  await user.click(screen.getByRole("link", { name: /play deck/i }));
+  await user.click(screen.getByRole("link", { name: /play/i }));
   expect(window.location.pathname).toMatch(/^\/pc\/coach\/.+/);
 });

--- a/apps/pronunco/src/__tests__/Router.test.tsx
+++ b/apps/pronunco/src/__tests__/Router.test.tsx
@@ -1,15 +1,16 @@
-/// <reference types="vitest" />
 // @vitest-environment jsdom
+/// <reference types="vitest" />
 import { render, screen } from "@testing-library/react";
 import { describe, it, expect, vi, afterAll } from "vitest";
-import App from "@/App";
-import { SettingsProvider } from "@/features/core/settings-context";
-import { DeckProvider } from "@/features/deck-context";
 
 const deck = { id: "test", title: "T", lang: "en", updatedAt: 0 };
 vi.mock("dexie-react-hooks", () => ({ useLiveQuery: () => [deck] }));
 vi.mock("../db", () => ({ db: {} }));
 vi.mock("coach-ui", () => ({ PronunciationCoachUI: () => <div>Dummy deck</div> }));
+
+import App from "@/App";
+import { SettingsProvider } from "@/features/core/settings-context";
+import { DeckProvider } from "@/features/deck-context";
 
 afterAll(() => {
   vi.unmock("coach-ui");
@@ -28,7 +29,7 @@ describe("PronunCo routes", () => {
     expect(screen.getByText(/deck manager/i)).toBeInTheDocument();
   });
 
-  it("renders CoachPage at /pc/coach/:id", () => {
+  it("renders CoachPage at /pc/coach/:id", async () => {
     window.history.pushState({}, "", "/pc/coach/test");
     render(
       <SettingsProvider>
@@ -37,6 +38,6 @@ describe("PronunCo routes", () => {
         </DeckProvider>
       </SettingsProvider>
     );
-    expect(screen.getByText(/dummy deck/i, { exact: false })).toBeInTheDocument();
+    expect(await screen.findByText(/dummy deck/i)).toBeInTheDocument();
   });
 });

--- a/apps/pronunco/src/components/DeckManager.tsx
+++ b/apps/pronunco/src/components/DeckManager.tsx
@@ -224,7 +224,7 @@ export default function DeckManager() {
               <td>{d.title}</td>
               <td>{d.lang}</td>
               <td className="text-center">
-                <Link to={`../coach/${d.id}`} aria-label="Play deck">
+                <Link to={`../coach/${d.id}`} aria-label="Play">
                   ▶
                 </Link>
               </td>

--- a/apps/pronunco/src/test/setupMocks.ts
+++ b/apps/pronunco/src/test/setupMocks.ts
@@ -1,10 +1,19 @@
 import React from 'react'
 import { vi } from 'vitest'
 // Redirect coach-ui imports that still point at Sober-Body
-vi.mock("../../../apps/sober-body/src/features/games/deck-context", async () =>
+vi.mock("../../../../apps/sober-body/src/features/games/deck-context", async () =>
   await import("@/features/deck-context")
-)
-vi.mock("../../../apps/sober-body/src/features/core/settings-context", async () =>
-  await import("@/features/core/settings-context")
-)
+);
+vi.mock(
+  "../../../../apps/sober-body/src/features/core/settings-context",
+  () => ({
+    // minimal but complete shape Coach-UI expects
+    useSettings: () => ({
+      ttsEnabled: false,
+      srEnabled: false,
+      locale: "en-US",
+      nativeLang: "en",
+    }),
+  }),
+);
 vi.mock('coach-ui', () => ({ PronunciationCoachUI: () => React.createElement('div', null, 'Dummy deck') }));


### PR DESCRIPTION
## Summary
- correct coach-ui import mocks
- move mocks above imports in LinkNavigation and Router tests
- update play link query
- clean coach page test

## Testing
- `pnpm test:unit:pc` *(fails: useDecks must be used within DeckProvider)*

------
https://chatgpt.com/codex/tasks/task_e_686e6637fa50832b95afc71844ed8f28