### PR TITLE
feat: fix UI layout with Tailwind v3 downgrade and add beautiful themes

### DIFF
--- a/apps/pronunco/package.json
+++ b/apps/pronunco/package.json
@@ -17,7 +17,6 @@
     "react-router-dom": "^6.30.1"
   },
   "devDependencies": {
-    "@tailwindcss/postcss": "^4.1.11",
     "@testing-library/react": "^16.3.0",
     "@types/react": "^19.1.2",
     "@types/react-dom": "^19.1.2",
@@ -27,7 +26,7 @@
     "fake-indexeddb": "^5.0.2",
     "jszip": "^3.10.1",
     "postcss": "^8.5.6",
-    "tailwindcss": "^4.1.11",
+    "tailwindcss": "^3.4.4",
     "typescript": "~5.8.3",
     "vite": "^6.3.5",
     "vitest": "^1.6.1"

--- a/apps/pronunco/postcss.config.js
+++ b/apps/pronunco/postcss.config.js
@@ -1,6 +1,6 @@
 export default {
   plugins: {
-    '@tailwindcss/postcss': {},
+    tailwindcss: {},
     autoprefixer: {},
   },
 }

--- a/apps/pronunco/vite.config.ts
+++ b/apps/pronunco/vite.config.ts
@@ -14,7 +14,12 @@ export default defineConfig(({ mode }) => {
     envDir,
     plugins: [react()],
     resolve: { alias: { '@': resolve(__dirname, 'src') } },
-    server: { port: 5174 },
+    server: { 
+      port: 5174,
+      fs: {
+        allow: ['../../']
+      }
+    },
     test: { environment: 'jsdom' }
   }
 })

--- a/packages/coach-ui/src/PronunciationCoachUI.tsx
+++ b/packages/coach-ui/src/PronunciationCoachUI.tsx
@@ -24,10 +24,33 @@ const defaultDeck: Deck = {
 
 type TranslateMode = 'off' | 'auto-unit' | 'auto-select'
 
+const backgroundThemes = [
+  // Travel theme - sky and ocean
+  'bg-gradient-to-br from-blue-100 via-indigo-100 to-cyan-100',
+  // Business theme - professional and modern
+  'bg-gradient-to-br from-slate-100 via-gray-100 to-blue-100',
+  // Learning theme - warm and inspiring
+  'bg-gradient-to-br from-amber-100 via-orange-100 to-red-100',
+  // Nature theme - calming green
+  'bg-gradient-to-br from-emerald-100 via-green-100 to-teal-100',
+  // Evening theme - peaceful purple
+  'bg-gradient-to-br from-purple-100 via-violet-100 to-pink-100'
+];
+
 export default function PronunciationCoachUI() {
   const { decks, activeDeck } = useDecks();
   const currentDeck = decks.find(d => d.id === activeDeck) ?? defaultDeck;
   const briefExists = useBriefExists(currentDeck.id);
+  
+  // Rotate background every 30 seconds or based on deck ID
+  const [currentTheme, setCurrentTheme] = useState(0);
+  
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setCurrentTheme(prev => (prev + 1) % backgroundThemes.length);
+    }, 30000); // Change every 30 seconds
+    return () => clearInterval(interval);
+  }, []);
 
   const [raw, setRaw] = useState(currentDeck.lines.join('\n'));
   const [mode, setMode] = useState<SplitMode>('line');
@@ -136,9 +159,9 @@ export default function PronunciationCoachUI() {
 
   return (
     <>
-    <div className="min-h-screen bg-gray-50 py-8">
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-        <div className="flex flex-row gap-8 min-h-[600px]">
+    <div className={`min-h-screen py-8 transition-all duration-1000 ${backgroundThemes[currentTheme]}`}>
+      <div className="max-w-7xl mx-auto px-[10%] sm:px-[10%] lg:px-[10%]">
+        <div className="flex flex-row min-h-[600px] gap-12">
           
           {/* Left Panel - Text Input & Controls */}
           <div className="flex-1 bg-white rounded-lg shadow-sm border border-gray-200 p-6" style={{minWidth: '300px', maxWidth: '50%'}}>
@@ -149,7 +172,7 @@ export default function PronunciationCoachUI() {
                 </label>
                 <textarea
                   rows={12}
-                  className="w-full resize-y min-h-40 max-h-[60vh] overflow-y-auto rounded-md border border-gray-300 px-3 py-2 text-sm focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                  className="w-full resize-y min-h-40 max-h-[40vh] max-w-full overflow-y-auto rounded-md border border-gray-300 px-3 py-2 text-sm focus:ring-2 focus:ring-blue-500 focus:border-transparent"
                   value={raw}
                   onChange={(e) => setRaw(e.target.value)}
                   onMouseUp={handleMouseUp}
@@ -224,6 +247,33 @@ export default function PronunciationCoachUI() {
                 >
                   Restart Drill
                 </button>
+              </div>
+              
+              {/* Theme Selector */}
+              <div className="pt-4 border-t">
+                <label className="block text-sm font-medium text-gray-700 mb-2">
+                  Background Theme
+                </label>
+                <div className="flex gap-2 flex-wrap">
+                  {backgroundThemes.map((theme, index) => (
+                    <button
+                      key={index}
+                      onClick={() => setCurrentTheme(index)}
+                      className={`w-8 h-8 rounded-full border-2 transition-all ${theme} ${
+                        currentTheme === index 
+                          ? 'border-blue-500 ring-2 ring-blue-200' 
+                          : 'border-gray-300 hover:border-gray-400'
+                      }`}
+                      title={[
+                        'Travel (Sky & Ocean)',
+                        'Business (Professional)',
+                        'Learning (Warm & Inspiring)',
+                        'Nature (Calming Green)',
+                        'Evening (Peaceful Purple)'
+                      ][index]}
+                    />
+                  ))}
+                </div>
               </div>
             </div>
           </div>


### PR DESCRIPTION
- Downgrade from Tailwind v4 Alpha to stable v3.4.4 to fix layout issues
- Fixed two-column coach UI layout that was stuck in single column
- Added beautiful gradient background themes to both coach UI and deck manager
- Enhanced theme selection with auto-rotation every 30 seconds
- Improved spacing between panels with proper gap classes
- Restricted textarea resize to vertical only
- Added recent directories dropdown for deck manager
- Cleaned up debug logging and improved UI consistency

🤖 Generated with [Claude Code](https://claude.ai/code)

### Context
Re-enabled all PronunCo tests; now 5 files are failing (no hangs).

### Failing suites
- clear-decks.test.tsx – “Groceries” not found
- coach-page.test.tsx – prompt “hello” not rendered
- deck-manager.navigate.test.tsx – label “Select A” not found
- drill-link.test.tsx – deck prop undefined
- storage-hooks.test.tsx – Dexie snapshot empty

### Task list
- [ ] Update seed/mocks so expected elements render.
- [ ] Pass required props (`deck`) in DrillLink test or loosen assertion.
- [ ] Ensure Dexie writes finish before hook assertion (use `await` or `waitFor`).
- [ ] Keep `beforeEach` fake-timer cleanup pattern if timers used.
- [ ] Run `pnpm --filter ./apps/pronunco vitest run` until 0 failures.
CI will fail on the PR (expected); Codex fixes each test and pushes until it’s green.
