### PR TITLE
Implement teacher drill wizard

### DIFF
--- a/apps/pronunco/__tests__/new-drill-wizard.test.tsx
+++ b/apps/pronunco/__tests__/new-drill-wizard.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+import NewDrillWizard from '../src/components/NewDrillWizard';
+import { SettingsProvider } from '../src/features/core/settings-context';
+
+vi.mock('../src/openai', () => ({
+  default: { chat: { completions: { create: vi.fn(async () => ({ choices: [{ message: { content: 'a\nb\nc' } }] })) } } }
+}));
+
+const add = vi.fn(async (d:any)=>'1');
+vi.mock('../src/db', () => ({ db: () => ({ decks: { add } }) }));
+vi.mock('../src/toast', () => ({ default: { success: vi.fn() } }));
+
+const renderWizard = () =>
+  render(
+    <MemoryRouter>
+      <SettingsProvider>
+        <NewDrillWizard open onClose={() => {}} />
+      </SettingsProvider>
+    </MemoryRouter>
+  );
+
+describe('NewDrillWizard', () => {
+  it('next disabled until topic entered', async () => {
+    renderWizard();
+    const next = screen.getByRole('button', { name: /next/i });
+    expect((next as HTMLButtonElement).disabled).toBe(true);
+    await userEvent.type(screen.getByPlaceholderText(/ordering food/i), 'Hi');
+    expect((next as HTMLButtonElement).disabled).toBe(false);
+  });
+
+  it('shows preview from openai and saves deck', async () => {
+    const user = userEvent.setup();
+    renderWizard();
+    await user.type(screen.getByPlaceholderText(/ordering food/i), 'topic');
+    await user.click(screen.getByRole('button', { name: /next/i }));
+    await screen.findByRole('button', { name: /save & exit/i });
+    await user.click(screen.getByRole('button', { name: /save & exit/i }));
+    expect(add).toHaveBeenCalled();
+    const row = add.mock.calls[0][0];
+    expect(row.lines.length).toBe(3);
+  });
+});

--- a/apps/pronunco/package.json
+++ b/apps/pronunco/package.json
@@ -12,6 +12,7 @@
     "coach-ui": "workspace:*",
     "dexie-react-hooks": "^1.1.7",
     "idb-keyval": "^6.2.2",
+    "openai": "^4.104.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router-dom": "^6.30.1"

--- a/apps/pronunco/src/components/DeckManager.tsx
+++ b/apps/pronunco/src/components/DeckManager.tsx
@@ -13,6 +13,8 @@ import {
   saveRecentDeckDir,
 } from "../../../../packages/core-storage/src/ui-store";
 import { exportDeckZip } from "../exportDeckZip";
+import NewDrillWizard from "./NewDrillWizard";
+import { useSettings } from "../features/core/settings-context";
 
 const backgroundThemes = [
   'bg-gradient-to-br from-blue-100 via-indigo-100 to-cyan-100',
@@ -27,11 +29,13 @@ export default function DeckManager() {
   const jsonRef = useRef<HTMLInputElement>(null);
   const pickerOpen = useRef(false);
   const navigate = useNavigate();
+  const { settings } = useSettings();
   const decks = useLiveQuery(() => db().decks?.toArray() ?? [], [], []) || [];
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
   const [recentDirs, setRecentDirs] = useState<Array<{name: string, handle: FileSystemDirectoryHandle, timestamp: number}>>([]);
   const [showRecentDirs, setShowRecentDirs] = useState(false);
   const [currentTheme, setCurrentTheme] = useState(0);
+  const [showWizard, setShowWizard] = useState(false);
 
   useEffect(() => {
     const interval = setInterval(() => {
@@ -252,6 +256,9 @@ export default function DeckManager() {
         <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
           <h2 className="text-2xl font-bold mb-4">Deck Manager</h2>
           <div className="flex gap-4 mb-4">
+            {settings.role === 'teacher' && (
+              <button className="px-4 py-2 bg-green-600 text-white rounded-md hover:bg-green-700 focus:ring-2 focus:ring-green-500 focus:outline-none transition-colors" onClick={()=>setShowWizard(true)}>➕ New Drill</button>
+            )}
             <button className="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 focus:ring-2 focus:ring-blue-500 focus:outline-none transition-colors" onClick={pickZip}>Import ZIP</button>
             <div className="relative inline-block">
               <button className="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 focus:ring-2 focus:ring-blue-500 focus:outline-none transition-colors" onClick={pickJson}>Import folder</button>
@@ -315,6 +322,7 @@ export default function DeckManager() {
       </div>
       <input ref={zipRef} type="file" accept="application/zip" hidden onChange={onZipInput} />
       <input ref={jsonRef} type="file" hidden webkitdirectory="" multiple onChange={onJsonInput} />
+      <NewDrillWizard open={showWizard} onClose={()=>setShowWizard(false)} />
     </div>
   );
 }

--- a/apps/pronunco/src/components/GrammarModal.tsx
+++ b/apps/pronunco/src/components/GrammarModal.tsx
@@ -1,0 +1,18 @@
+import { useState, useEffect } from 'react';
+
+export default function GrammarModal({ open, text, onSave, onClose }:{ open:boolean; text:string; onSave:(t:string)=>void; onClose:()=>void }) {
+  const [val,setVal] = useState(text);
+  useEffect(()=>{ if(open) setVal(text); },[open,text]);
+  if(!open) return null;
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+      <div className="bg-white p-4 rounded w-96 space-y-2">
+        <textarea className="border w-full h-40 p-1" value={val} onChange={e=>setVal(e.target.value)} />
+        <div className="text-right space-x-2">
+          <button className="border px-2" onClick={onClose}>Cancel</button>
+          <button className="border px-2" onClick={()=>{onSave(val);onClose();}}>Save</button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/pronunco/src/components/NewDrillWizard.tsx
+++ b/apps/pronunco/src/components/NewDrillWizard.tsx
@@ -1,0 +1,89 @@
+import { useState } from 'react';
+import { LANGS } from '../../../../packages/pronunciation-coach/src/langs';
+import { useNavigate } from 'react-router-dom';
+import openai from '../openai';
+import { db } from '../db';
+import GrammarModal from './GrammarModal';
+import toast from '../toast';
+import { useSettings } from '../features/core/settings-context';
+
+export default function NewDrillWizard({ open, onClose }:{ open:boolean; onClose:()=>void }) {
+  const { settings } = useSettings();
+  const [step,setStep]=useState(1);
+  const [topic,setTopic]=useState('');
+  const [count,setCount]=useState(10);
+  const [lang,setLang]=useState(settings.locale);
+  const [preview,setPreview]=useState('');
+  const [loading,setLoading]=useState(false);
+  const [grammar,setGrammar]=useState('');
+  const [editOpen,setEditOpen]=useState(false);
+  const navigate=useNavigate();
+
+  if(!open) return null;
+
+  const generate=async()=>{
+    setLoading(true);
+    try{
+      const res=await openai.chat.completions.create({
+        model:'gpt-4o-mini',
+        messages:[{role:'user',content:`${topic} (${lang}) ${count} lines`}]
+      });
+      const text=res.choices[0].message.content || '';
+      setPreview(text);
+      setStep(2);
+    }finally{setLoading(false);}
+  };
+
+  const save=async()=>{
+    const lines=preview.split('\n').filter(Boolean);
+    const deckId=await db().decks.add({
+      title: topic,
+      type: 'pronun',
+      lang,
+      grammar,
+      lines,
+      createdAt: Date.now(),
+      updatedAt: Date.now()
+    });
+    navigate(`/pc/coach/${deckId}`);
+    toast.success('Drill created 🎉');
+    onClose();
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+      <div className="bg-white p-4 rounded w-96 space-y-4">
+        {step===1 && (
+          <>
+            <h2 className="font-semibold">New Drill</h2>
+            <input className="border w-full p-1" placeholder="Ordering food in Spain" value={topic} onChange={e=>setTopic(e.target.value)} />
+            <input type="number" className="border w-full p-1" min={1} max={30} value={count} onChange={e=>setCount(Number(e.target.value))} />
+            <select className="border w-full p-1" value={lang} onChange={e=>setLang(e.target.value)}>
+              {LANGS.map(l=>(<option key={l.code} value={l.code}>{l.label}</option>))}
+            </select>
+            <div className="text-right">
+              <button className="border px-2" disabled={!topic} onClick={generate}>Next →</button>
+            </div>
+          </>
+        )}
+        {step===2 && (
+          <>
+            {loading? (
+              <div>Generating drill…</div>
+            ):(
+              <blockquote className="border-l-4 pl-3 italic whitespace-pre-line">{preview}</blockquote>
+            )}
+            <div className="flex justify-between">
+              <button className="border px-2" onClick={()=>setStep(1)}>⟲ Back</button>
+              <div className="space-x-2">
+                <button className="border px-2" onClick={()=>setEditOpen(true)}>Edit Grammar</button>
+                <button className="border px-2" onClick={save}>Save & Exit</button>
+              </div>
+            </div>
+          </>
+        )}
+      </div>
+      <GrammarModal open={editOpen} text={grammar} onSave={setGrammar} onClose={()=>setEditOpen(false)} />
+    </div>
+  );
+}

--- a/apps/pronunco/src/features/core/settings-context.tsx
+++ b/apps/pronunco/src/features/core/settings-context.tsx
@@ -13,7 +13,8 @@ const DEFAULTS: Required<Settings> = {
   nativeLang: 'en',
   locale: 'en',
   slowSpeech: false,
-  useAzure: false
+  useAzure: false,
+  role: 'student'
 }
 const SettingsContext = createContext<SettingsValue | undefined>(undefined)
 export function SettingsProvider({ children }: { children: React.ReactNode }) {

--- a/apps/pronunco/src/features/core/storage.ts
+++ b/apps/pronunco/src/features/core/storage.ts
@@ -19,6 +19,7 @@ export interface Settings {
   locale?: string
   slowSpeech?: boolean
   useAzure?: boolean
+  role?: string
 }
 
 export async function loadSettings(): Promise<Settings | undefined> {

--- a/apps/pronunco/src/openai.ts
+++ b/apps/pronunco/src/openai.ts
@@ -1,0 +1,15 @@
+export const openai = {
+  chat: {
+    completions: {
+      async create(opts: any) {
+        const res = await fetch('https://api.openai.com/v1/chat/completions', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${process.env.OPENAI_API_KEY}` },
+          body: JSON.stringify(opts),
+        });
+        return res.json();
+      },
+    },
+  },
+};
+export default openai;

--- a/apps/pronunco/src/toast.ts
+++ b/apps/pronunco/src/toast.ts
@@ -1,0 +1,10 @@
+export const toast = {
+  success(msg: string) {
+    const el = document.createElement('div');
+    el.className = 'fixed top-4 right-4 bg-green-600 text-white px-4 py-2 rounded shadow z-50';
+    el.textContent = msg;
+    document.body.appendChild(el);
+    setTimeout(() => el.remove(), 3000);
+  }
+};
+export default toast;

--- a/apps/sober-body/src/features/core/settings-context.test.tsx
+++ b/apps/sober-body/src/features/core/settings-context.test.tsx
@@ -33,7 +33,7 @@ describe('SettingsProvider persistence', () => {
     await waitFor(() => expect(storage.loadSettings).toHaveBeenCalled())
     fireEvent.click(screen.getByRole('button', { name: /change/i }))
     await waitFor(() => {
-      expect(storage.saveSettings).toHaveBeenCalledWith({ weightKg: 80, sex: 'm', beta: DEFAULT_BETA, nativeLang: 'en', locale: 'en', slowSpeech: false })
+      expect(storage.saveSettings).toHaveBeenCalledWith({ weightKg: 80, sex: 'm', beta: DEFAULT_BETA, nativeLang: 'en', locale: 'en', slowSpeech: false, role: 'student' })
     })
     first.unmount()
     render(

--- a/apps/sober-body/src/features/core/settings-context.tsx
+++ b/apps/sober-body/src/features/core/settings-context.tsx
@@ -12,7 +12,8 @@ const DEFAULTS: Required<Settings> = {
   beta: DEFAULT_BETA,
   nativeLang: 'en',
   locale: 'en',
-  slowSpeech: false
+  slowSpeech: false,
+  role: 'student'
 }
 const SettingsContext = createContext<SettingsValue | undefined>(undefined)
 export function SettingsProvider({ children }: { children: React.ReactNode }) {

--- a/apps/sober-body/src/features/core/storage.ts
+++ b/apps/sober-body/src/features/core/storage.ts
@@ -18,6 +18,7 @@ export interface Settings {
   nativeLang?: string
   locale?: string
   slowSpeech?: boolean
+  role?: string
 }
 
 export async function loadSettings(): Promise<Settings | undefined> {


### PR DESCRIPTION
## Summary
- extend settings to include user role
- add toast helper and simple OpenAI wrapper
- create GrammarModal and NewDrillWizard components
- show "New Drill" button for teachers
- include unit tests for wizard flow

## Testing
- `pnpm test:unit:pc`

------
https://chatgpt.com/codex/tasks/task_e_68723777cd1c832b828c58a41506c7ce