### PR TITLE
Update PronunCo Sprint-4 backlog table

### DIFF
--- a/docs/pronunco/WORK-TECH-FEATURE.md
+++ b/docs/pronunco/WORK-TECH-FEATURE.md
@@ -1,6 +1,23 @@
 # PronunCo – Work / Tech Feature Back-Log
 *(initial skeleton – import tasks from sprint board as needed)*
 
-| ID | Epic | Sprint | Owner | Status |
-|----|------|--------|-------|--------|
-| PN-041 | Dexie outbox + sync | 4 | Claude | in-progress |
+| ID   | Epic / Feature                              | Sprint | Owner   | Status        |
+|------|---------------------------------------------|--------|---------|---------------|
+| PN-041 | Dexie **outbox** table + `useSync()` flush | 4 | Claude  | in-progress |
+| PN-042 | Supabase `challenge_scores` table + Top-10 API | 4 | Claude | pending (waits on PN-041) |
+| PN-043 | **Usage watchdog** & daily budget alert for Azure | 4 | Claude | in-progress |
+| PN-044 | `usePronunciationScore` hook (Azure) | 4 | Claude | merged #194 |
+| PN-045 | Quick-Challenge **share page** (`/c`) | 4 | Gemini | merged #193 |
+| PN-046 | **Share-card generator** (html2canvas) | 4 | Gemini | merged #193 |
+| PN-047 | Responsive mobile / tablet break-points | 4 | Gemini | in-progress |
+| PN-048 | Teacher **Create-Drill Wizard** (topic + lines) | 4 | GPT | in-progress |
+| PN-049 | Grammar-edit modal integration | 4 | GPT | merged #191 |
+| PN-050 | Playwright smoke test (deck → first line) | 4 | open   | backlog |
+| PN-051 | Re-enable deep routing tests | 4 | open   | backlog |
+| PN-052 | Deck **folder tree / drag-and-drop** | 4+ | open   | ice-box |
+
+> **Legend**  
+> *merged # xxx* – already on main  
+> *in-progress* – branch open this sprint  
+> *backlog* – should land before Sprint 4 closes  
+> *ice-box* – nice-to-have, no capacity yet


### PR DESCRIPTION
## Summary
- populate the PronunCo tech backlog table with all Sprint-4 items

## Testing
- `git status --short`
- `git push -u origin docs/populate-pronunco-wotefe` *(fails: no remote)*

------
https://chatgpt.com/codex/tasks/task_e_6872cd90b554832bb175232e10c1e317