### PR TITLE
Add Q3 2025 founder priorities

### DIFF
--- a/docs/pronunco/WP4_go_to_market.md
+++ b/docs/pronunco/WP4_go_to_market.md
@@ -24,3 +24,18 @@ Azure cost ≈ \$0.0004 / 15-sec clip ⇒ break-even at ~1 k clips / user / mo.
 ## 4 Launch timeline
 * **Beta** – Sep 2025 (invite teachers)  
 * **Public** – Nov 2025  
+
+## Q3 2025 Priorities _(Founder update — July 2025)_
+
+| Rank | Epic | Outcomes | Docs link |
+|------|------|----------|-----------|
+| **1** | **Finalize Dexie migration** (per-app DBs) | Smooth deck import/delete; sets stage for multi-PWA deployment. | See WP-2 §3 |
+| **2** | **Azure Pronunciation Assessment (Pro toggle)** | Cloud-grade accuracy → justifies subscription tier.  | WP-3 §4 |
+| **3** | **Responsive mobile UX pass** | 40-50 % of users drill on phones; improves retention. | WP-2 §3 UI layer |
+| **4** | **Per-deck progress tracking** | Badges & teacher reports; unlocks leaderboard later. | WP-3 §5 |
+| **5** | **Cypress smoke test in CI** | Guards against deck-selection regressions. | Internal QA ADR |
+
+_Note: Leaderboard & marketplace remain stretch goals for Q4 unless Azure toggle
+ships early and costs remain within CAC < $0.60 per activated user._
+
+*Added by Founder chat — preserves long-horizon context while Dev-lead tackles implementation details in Sprint #3.*


### PR DESCRIPTION
## Summary
- add Q3 2025 priorities table to `docs/pronunco/WP4_go_to_market.md`

## Testing
- `pnpm -r lint` *(fails: Unexpected any etc.)*
- `pnpm test:unit:sb`
- `pnpm test:unit:pc`

------
https://chatgpt.com/codex/tasks/task_e_6872f77d3118832bbe51c8f8455a954e