### PR TITLE
docs: move GTM and add user journey

### DIFF
--- a/docs/pronunco/BUSINESS-STRATEGIC.md
+++ b/docs/pronunco/BUSINESS-STRATEGIC.md
@@ -61,3 +61,30 @@
 #  Quick-win bucket (≤ 1 day):
 #  – Remember last import folder – Deck progress badge – Add Cypress job to Actions
 ## ─────────────────────────────────────────────────────────
+## 💡 Vision & Go-to-Market
+
+## 2 Acquisition channels
+* Challenge link virality
+* SEO blog – “pronounce Portuguese R sound”
+* Teacher affiliate (30 % rev-share)
+
+## 4 Launch timeline
+* **Beta** – Sep 2025 (invite teachers)
+* **Public** – Nov 2025
+
+## Q3 2025 Priorities _(Founder update — July 2025)_
+
+| Rank | Epic | Outcomes | Docs link |
+|------|------|----------|-----------|
+| **1** | **Finalize Dexie migration** (per-app DBs) | Smooth deck import/delete; sets stage for multi-PWA deployment. | See WP-2 §3 |
+| **2** | **Azure Pronunciation Assessment (Pro toggle)** | Cloud-grade accuracy → justifies subscription tier.  | WP-3 §4 |
+| **3** | **Responsive mobile UX pass** | 40-50 % of users drill on phones; improves retention. | WP-2 §3 UI layer |
+| **4** | **Per-deck progress tracking** | Badges & teacher reports; unlocks leaderboard later. | WP-3 §5 |
+| **5** | **Cypress smoke test in CI** | Guards against deck-selection regressions. | Internal QA ADR |
+
+_Note: Leaderboard & marketplace remain stretch goals for Q4 unless Azure toggle
+ships early and costs remain within CAC < $0.60 per activated user._
+
+*Added by Founder chat — preserves long-horizon context while Dev-lead tackles implementation details in Sprint #3.*
+
+↗ See UX – User Journey for personas and funnel.

--- a/docs/pronunco/UX-USER-JOURNEY.md
+++ b/docs/pronunco/UX-USER-JOURNEY.md
@@ -1,0 +1,26 @@
+# UX – User Journey & Personas (Living Doc)
+
+## 1. Personas
+| Persona | Goals | Pain points | Pro features/cues |
+|---------|-------|-------------|-------------------|
+| Casual learner “Anna” | ... | ... | Azure heat-map feedback |
+| ESL Teacher “Mr. Kim” | ... | ... | Bulk deck share, leaderboard |
+
+## 2. Acquisition Paths
+1. **Organic search** → blog post → web-demo CTA
+2. **Teacher referral** → shared topic pack link → signup
+3. **Challenges on social** (Leaderboard share link)
+
+## 3. In-App Journey
+```mermaid
+graph TD
+  A[Landing] --> B{Auth?}
+  B -->|guest| C[Onboarding deck]
+  B -->|logged| D[Deck Manager]
+  D --> E[Coach / Drill] --> F[Leaderboard] ...
+```
+
+## 4. Drop-off Risks & Fix Ideas
+| Step | Metric | Risk | Mitigation |
+|------|--------|------|-----------|
+| Landing → signup | bounce rate | Long hero copy | A/B shorter headline |

--- a/docs/pronunco/WP4_go_to_market.md
+++ b/docs/pronunco/WP4_go_to_market.md
@@ -2,7 +2,7 @@
 version: 0.1-draft  
 status: living  
 ---
-# WP-4 · Go-To-Market & Monetization
+# WP-4 – Pricing Model
 
 ## 1 Tier matrix
 | Feature | Free | Pro ($9/mo) |
@@ -13,29 +13,5 @@ status: living
 | Unlimited custom decks | ⚠ 5 / mo | ✔ |
 | Teacher dashboard | ✖ | ✔ |
 
-## 2 Acquisition channels
-* Challenge link virality  
-* SEO blog – “pronounce Portuguese R sound”  
-* Teacher affiliate (30 % rev-share)
-
-## 3 Pricing rationale
+## 2 Pricing rationale
 Azure cost ≈ \$0.0004 / 15-sec clip ⇒ break-even at ~1 k clips / user / mo.
-
-## 4 Launch timeline
-* **Beta** – Sep 2025 (invite teachers)  
-* **Public** – Nov 2025  
-
-## Q3 2025 Priorities _(Founder update — July 2025)_
-
-| Rank | Epic | Outcomes | Docs link |
-|------|------|----------|-----------|
-| **1** | **Finalize Dexie migration** (per-app DBs) | Smooth deck import/delete; sets stage for multi-PWA deployment. | See WP-2 §3 |
-| **2** | **Azure Pronunciation Assessment (Pro toggle)** | Cloud-grade accuracy → justifies subscription tier.  | WP-3 §4 |
-| **3** | **Responsive mobile UX pass** | 40-50 % of users drill on phones; improves retention. | WP-2 §3 UI layer |
-| **4** | **Per-deck progress tracking** | Badges & teacher reports; unlocks leaderboard later. | WP-3 §5 |
-| **5** | **Cypress smoke test in CI** | Guards against deck-selection regressions. | Internal QA ADR |
-
-_Note: Leaderboard & marketplace remain stretch goals for Q4 unless Azure toggle
-ships early and costs remain within CAC < $0.60 per activated user._
-
-*Added by Founder chat — preserves long-horizon context while Dev-lead tackles implementation details in Sprint #3.*


### PR DESCRIPTION
## Summary
- shift go-to-market discussion from `WP4_go_to_market.md` into `BUSINESS-STRATEGIC.md`
- trim `WP4_go_to_market.md` down to pricing table and break-even equation
- create `UX-USER-JOURNEY.md` with persona and funnel skeleton
- add cross link in the business strategy doc

## Testing
- `pnpm install`
- `pnpm test:unit:sb`
- `pnpm test:unit:pc`


------
https://chatgpt.com/codex/tasks/task_e_6873166bff88832b9886b350c1827043