### PR TITLE
docs: add personas & growth experiments tables

### DIFF
--- a/docs/pronunco/BUSINESS-STRATEGIC.md
+++ b/docs/pronunco/BUSINESS-STRATEGIC.md
@@ -45,6 +45,7 @@
 #  Engagement & sharing (SPRINT 4+)
 #  • Leaderboard back-end (Supabase challenge_scores) | Builds on completed challenge system for social proof & virality
 #  • Topic-Pack marketplace (GitHub Pages CDN / Supabase bucket) | Leverage folder organization for community growth channel
+#  • Growth Experiment implementation | Medium priority
 #  -------------------------------------------------------
 #  Monetization (READY FOR IMPLEMENTATION)
 #  • Stripe checkout & "pro" flag (localStorage + JWT stub) | Pays for Azure calls - FOUNDATION COMPLETE
@@ -62,6 +63,8 @@
 #  – Remember last import folder – Deck progress badge – Add Cypress job to Actions
 ## ─────────────────────────────────────────────────────────
 ## 💡 Vision & Go-to-Market
+
+↗ Growth backlog lives in [UX-USER-JOURNEY.md ▸ Growth Experiments](UX-USER-JOURNEY.md#🚀-growth-experiments-rolling-backlog)
 
 ## 2 Acquisition channels
 * Challenge link virality

--- a/docs/pronunco/UX-USER-JOURNEY.md
+++ b/docs/pronunco/UX-USER-JOURNEY.md
@@ -1,5 +1,16 @@
 # UX – User Journey & Personas (Living Doc)
 
+## 🌟 Personas (topic-island model)
+
+| Persona | Context “Island” | Pain Today | Win with PronunCo |
+|---------|------------------|------------|-------------------|
+| **Anna – Biz Traveler** | Airport → Taxi → Hotel | Crams phrasebook on plane; zero speaking practice | 15-min plane-mode drills + Azure heat-map assure intelligibility |
+| **Mia – Student-Athlete** | Press interviews at world events | Tutor sessions cancelled during travel | Sport-press deck + leaderboard with teammates |
+| **Grace – Relief Volunteer** | Disaster-relief greetings & supply requests | Offline PDFs only; shaky pronunciation | Offline PWA + badge shows 90 % intelligibility |
+| **Carlos – Ops Manager** | Staff rotations abroad | LMS too generic; no visibility | Private company deck + progress dashboard |
+| **Coach Kim – National Team Coach** | Athletes in Olympic village | Union rules—no extra staff time | Plug-and-play topic deck; leaderboard gamifies |
+| **Dr. Patel – Clinic Director** | Rural clinic rotations | Patients struggle with English | Medical vocab pack + on-prem leaderboard |
+
 ## 1. Personas
 | Persona | Goals | Pain points | Pro features/cues |
 |---------|-------|-------------|-------------------|
@@ -24,3 +35,13 @@ graph TD
 | Step | Metric | Risk | Mitigation |
 |------|--------|------|-----------|
 | Landing → signup | bounce rate | Long hero copy | A/B shorter headline |
+
+## 🚀 Growth Experiments (rolling backlog)
+
+| ID | Channel | Hook | KPI |
+|----|---------|------|-----|
+| **TikTok-Stitch-01** | TikTok stitch challenge | “Beat my 92 % Taxi Spanish score!” (heat-map video) | # of stitches, click-thru to `/challenge/taxi-es` |
+| **IG-Story-Airport** | Instagram Story + Link sticker | 15-sec reel: user says “¿Dónde está mi equipaje?” → green heat-map | Swipe-ups to `/demo?deck=airport-mini` |
+| **FB-Nomad-Pack** | Post in Digital-Nomad FB groups | Free mini Spanish airport deck ZIP | ZIP downloads |
+| **WeeklyLeaderboardTweet** | Twitter bot | Auto-tweet top-3 scores every Monday | Impressions, clicks |
+| **SlackSlashCommand-PoC** | Slack integration | `/drill luggage-es` inside corp Slack | Slash-command usage / day |

--- a/docs/pronunco/WORK-TECH-FEATURE.md
+++ b/docs/pronunco/WORK-TECH-FEATURE.md
@@ -42,3 +42,7 @@
 > *in-progress* – branch open this sprint  
 > *backlog* – should land before Sprint 4 closes  
 > *ice-box* – nice-to-have, no capacity yet
+
+### Backlog
+
+* [Implement first TikTok Stitch challenge (ref: TikTok-Stitch-01)](UX-USER-JOURNEY.md#🚀-growth-experiments-rolling-backlog)


### PR DESCRIPTION
## Summary
- add expanded personas using topic-island model
- add Growth Experiments backlog table
- link Growth Experiments from business strategy docs
- mention Growth Experiment implementation in the roadmap
- add backlog task for TikTok Stitch challenge

## Testing
- `pnpm test:unit:sb`
- `pnpm test:unit:pc`


------
https://chatgpt.com/codex/tasks/task_e_687321df3998832b97768775c3acee50