### PR TITLE
Docs: add security epics PN-056 & PN-057, mark Sprint-4 start

### DIFF
--- a/docs/pronunco/BUSINESS-STRATEGIC.md
+++ b/docs/pronunco/BUSINESS-STRATEGIC.md
@@ -89,5 +89,7 @@ _Note: Leaderboard & marketplace remain stretch goals for Q4 unless Azure toggle
 ships early and costs remain within CAC < $0.60 per activated user._
 
 *Added by Founder chat — preserves long-horizon context while Dev-lead tackles implementation details in Sprint #3.*
+## Risk & Trust
+- Ship kid-safe filter + teacher-signed decks to reassure schools & parents.
 
 ↗ See UX – User Journey for personas and funnel.

--- a/docs/pronunco/WORK-TECH-FEATURE.md
+++ b/docs/pronunco/WORK-TECH-FEATURE.md
@@ -36,6 +36,8 @@
 | PN-052 | Deck **folder tree / drag-and-drop** | 3 | Claude | merged (folder tree complete, drag-drop future) |
 | PN-053 | **Smart folder naming** with topic analysis | 3 | Claude | merged (suggests "Food & Dining" etc.) |
 | PN-054 | **Share Challenge URLs** with encoded data | 3 | Claude | merged (via Friend-Challenge feature) |
+| PN-056 | Inappropriate-content guard (word-list, flag modal, report queue) | 4 | Gemini + Claude | backlog |
+| PN-057 | Deck signature & verify (hash + optional Ed25519) | 4 | Gemini + GPT | backlog |
 
 > **Legend**  
 > *merged # xxx* – already on main  


### PR DESCRIPTION
## Summary
- add new security backlog items PN-056 and PN-057
- document risk & trust plan for kid‑safe decks

## Testing
- `pnpm install`
- `pnpm -r lint` *(fails: Unexpected any in DeckToolbar.tsx)*
- `git push` *(fails: remote origin not found)*

------
https://chatgpt.com/codex/tasks/task_e_68733a800468832b8d1b1cff7adee224