### PR TITLE
Add team-mode and leaderboard docs

### DIFF
--- a/docs/pronunco/BUSINESS-STRATEGIC.md
+++ b/docs/pronunco/BUSINESS-STRATEGIC.md
@@ -46,6 +46,14 @@
 #  • Leaderboard back-end (Supabase challenge_scores) | Builds on completed challenge system for social proof & virality
 #  • Topic-Pack marketplace (GitHub Pages CDN / Supabase bucket) | Leverage folder organization for community growth channel
 #  • Growth Experiment implementation | Medium priority
+#
+| Theme | Feature / Deliverable | Why it matters | Priority |
+|-------|-----------------------|----------------|----------|
+| Engagement & Sharing | **Team-Mode Deck** (invite link joins a group score board) | Corporate trips & classrooms learn together; boosts retention via peer pressure | Medium |
+| Engagement & Sharing | **One-click Share Link** (public or private) | Teachers or travellers can send a micro-deck in WhatsApp; viral channel | High |
+| Engagement & Sharing | **Self-hosted Leaderboard** (social embed) | Any user can drop a leaderboard iframe into FB profile or blog, creates UGC funnels | Medium |
+
+> 🔗 Detailed growth hooks live in [UX-USER-JOURNEY ▸ Growth Experiments](UX-USER-JOURNEY.md#🚀-growth-experiments-rolling-backlog).
 #  -------------------------------------------------------
 #  Monetization (READY FOR IMPLEMENTATION)
 #  • Stripe checkout & "pro" flag (localStorage + JWT stub) | Pays for Azure calls - FOUNDATION COMPLETE

--- a/docs/pronunco/UX-USER-JOURNEY.md
+++ b/docs/pronunco/UX-USER-JOURNEY.md
@@ -45,3 +45,6 @@ graph TD
 | **FB-Nomad-Pack** | Post in Digital-Nomad FB groups | Free mini Spanish airport deck ZIP | ZIP downloads |
 | **WeeklyLeaderboardTweet** | Twitter bot | Auto-tweet top-3 scores every Monday | Impressions, clicks |
 | **SlackSlashCommand-PoC** | Slack integration | `/drill luggage-es` inside corp Slack | Slash-command usage / day |
+| **TeamDash-01** | Internal Slack / Teams | `/team drill airport-es` → shared scoreboard | Active teams / week |
+| **ShareLink-WhatsApp** | WhatsApp / iMessage | One-tap link opens mini-deck; badge screenshot to sender | Click-to-drill % |
+| **EmbedLeaderboard-FB** | User FB profile / blog | iFrame shows top-10 friends on “Taxi Spanish” | Impressions, new sign-ups |

--- a/docs/pronunco/WORK-TECH-FEATURE.md
+++ b/docs/pronunco/WORK-TECH-FEATURE.md
@@ -48,3 +48,6 @@
 ### Backlog
 
 * [Implement first TikTok Stitch challenge (ref: TikTok-Stitch-01)](UX-USER-JOURNEY.md#🚀-growth-experiments-rolling-backlog)
+* Implement **Team-Mode Deck** backend table (`team_id, user_id, deck_id, score`).
+* Build **Share Link** generator & handler route.
+* Add **Embed Leaderboard** endpoint (`/embed/leaderboard/:slug`) – no auth.


### PR DESCRIPTION
## Summary
- outline team-mode features in Business Strategic
- note team-mode growth experiments
- backlog tech tasks for team-mode and leaderboards

## Testing
- `pnpm test:unit` *(fails: None of the selected packages has a "test:unit:*" script)*
- `pnpm lint` *(fails: ESLint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68733c77b394832bbd04cf6af609b4fa