### PR TITLE
docs(pronunco): add responsive side-nav to backlog

### DIFF
--- a/docs/pronunco/BUSINESS-STRATEGIC.md
+++ b/docs/pronunco/BUSINESS-STRATEGIC.md
@@ -41,6 +41,7 @@
 #  • Responsive layouts (phone / tablet) | 40-50 % users drill on mobile - CRITICAL PATH
 #  • Icon + tooltip component (🏠 Manage, 🏆 Challenge, 📖 Brief …) | Reduces onboarding friction
 #  • Teacher Brief drawer polish (markdown toolbar, quick ref search) | Improves teacher adoption
+#  • Side-Nav shell – keeps users one-click away from Coach, Decks, and Settings; improves daily retention.
 #  -------------------------------------------------------
 #  Engagement & sharing (SPRINT 4+)
 #  • Leaderboard back-end (Supabase challenge_scores) | Builds on completed challenge system for social proof & virality

--- a/docs/pronunco/WORK-TECH-FEATURE.md
+++ b/docs/pronunco/WORK-TECH-FEATURE.md
@@ -51,3 +51,7 @@
 * Implement **Team-Mode Deck** backend table (`team_id, user_id, deck_id, score`).
 * Build **Share Link** generator & handler route.
 * Add **Embed Leaderboard** endpoint (`/embed/leaderboard/:slug`) – no auth.
+
+| Status | Epic / Feature | Notes | Size |
+|--------|----------------|-------|------|
+| 🕒 TODO | **Responsive Side-Navigation shell** (Dashboard • Drill • Decks • Settings) | Collapsible rail on desktop, slide-in Sheet on mobile. Lays groundwork for future Dashboard & Leaderboard pages. | Medium |


### PR DESCRIPTION
## Summary
- add responsive side-nav shell entry to Work Tech Feature backlog
- mention side-nav shell in Business Strategic UI/UX notes

## Testing
- `pnpm test:unit`

------
https://chatgpt.com/codex/tasks/task_e_6873c011ae14832baed5a903075329f9