### PR TITLE
feat(pronunciation): implement Azure Speech Assessment with AI-powere…

### DIFF
--- a/packages/azure-speech/src/audioConverter.ts
+++ b/packages/azure-speech/src/audioConverter.ts
@@ -1,0 +1,93 @@
+/**
+ * Audio format converter for Azure Speech Services compatibility
+ * Converts WebM/Opus to WAV/PCM format that Azure expects
+ */
+
+export async function convertToWav(audioBlob: Blob): Promise<Blob> {
+  try {
+    // Create audio context
+    const audioContext = new (window.AudioContext || (window as any).webkitAudioContext)({
+      sampleRate: 16000 // Azure prefers 16kHz
+    });
+
+    // Convert blob to ArrayBuffer
+    const arrayBuffer = await audioBlob.arrayBuffer();
+    
+    // Decode audio data
+    const audioBuffer = await audioContext.decodeAudioData(arrayBuffer);
+    
+    // Get PCM data (mono channel)
+    const channelData = audioBuffer.getChannelData(0);
+    
+    // Convert float32 to int16 PCM
+    const pcmData = new Int16Array(channelData.length);
+    for (let i = 0; i < channelData.length; i++) {
+      // Clamp to [-1, 1] and convert to 16-bit
+      const sample = Math.max(-1, Math.min(1, channelData[i]));
+      pcmData[i] = sample * 0x7FFF;
+    }
+    
+    // Create WAV header
+    const wavHeader = createWavHeader(pcmData.length * 2, 16000, 1);
+    
+    // Combine header and data
+    const wavData = new Uint8Array(wavHeader.length + pcmData.length * 2);
+    wavData.set(wavHeader, 0);
+    wavData.set(new Uint8Array(pcmData.buffer), wavHeader.length);
+    
+    // Close audio context to free resources
+    await audioContext.close();
+    
+    return new Blob([wavData], { type: 'audio/wav' });
+    
+  } catch (error) {
+    console.error('Audio conversion failed:', error);
+    throw new Error(`Failed to convert audio to WAV: ${error instanceof Error ? error.message : 'Unknown error'}`);
+  }
+}
+
+function createWavHeader(dataLength: number, sampleRate: number, channels: number): Uint8Array {
+  const header = new ArrayBuffer(44);
+  const view = new DataView(header);
+  
+  // WAV header structure
+  const writeString = (offset: number, string: string) => {
+    for (let i = 0; i < string.length; i++) {
+      view.setUint8(offset + i, string.charCodeAt(i));
+    }
+  };
+  
+  writeString(0, 'RIFF');                                    // ChunkID
+  view.setUint32(4, 36 + dataLength, true);                 // ChunkSize
+  writeString(8, 'WAVE');                                    // Format
+  writeString(12, 'fmt ');                                   // Subchunk1ID
+  view.setUint32(16, 16, true);                              // Subchunk1Size
+  view.setUint16(20, 1, true);                               // AudioFormat (PCM)
+  view.setUint16(22, channels, true);                        // NumChannels
+  view.setUint32(24, sampleRate, true);                      // SampleRate
+  view.setUint32(28, sampleRate * channels * 2, true);       // ByteRate
+  view.setUint16(32, channels * 2, true);                    // BlockAlign
+  view.setUint16(34, 16, true);                              // BitsPerSample
+  writeString(36, 'data');                                   // Subchunk2ID
+  view.setUint32(40, dataLength, true);                      // Subchunk2Size
+  
+  return new Uint8Array(header);
+}
+
+/**
+ * Check if audio conversion is needed based on blob type
+ */
+export function needsConversion(audioBlob: Blob): boolean {
+  return !audioBlob.type.includes('wav') && !audioBlob.type.includes('audio/wav');
+}
+
+/**
+ * Get audio format info for debugging
+ */
+export function getAudioInfo(audioBlob: Blob) {
+  return {
+    type: audioBlob.type,
+    size: audioBlob.size,
+    needsConversion: needsConversion(audioBlob)
+  };
+}

--- a/packages/azure-speech/src/pronunciationAnalyzer.ts
+++ b/packages/azure-speech/src/pronunciationAnalyzer.ts
@@ -1,0 +1,183 @@
+/**
+ * AI-powered pronunciation analysis and drill generation
+ * Uses GPT-4o to analyze Azure Speech data and suggest targeted practice
+ */
+
+interface PhonemeAnalysis {
+  phoneme: string;
+  word: string;
+  accuracy: number;
+  position: string; // beginning, middle, end
+}
+
+interface DrillSuggestion {
+  focus: string;
+  explanation: string;
+  exercises: string[];
+  tips: string[];
+}
+
+export async function analyzeProblematicSounds(azureResponse: any): Promise<DrillSuggestion | null> {
+  try {
+    // Extract problematic phonemes (below 80% accuracy)
+    const problematicSounds = extractProblematicPhonemes(azureResponse);
+    
+    if (problematicSounds.length === 0) {
+      return null; // No issues found
+    }
+
+    // Generate AI-powered drill suggestions
+    const drillSuggestion = await generateDrillSuggestions(problematicSounds, azureResponse);
+    
+    return drillSuggestion;
+    
+  } catch (error) {
+    console.error('Failed to analyze pronunciation:', error);
+    return null;
+  }
+}
+
+function extractProblematicPhonemes(azureResponse: any): PhonemeAnalysis[] {
+  const problematic: PhonemeAnalysis[] = [];
+  
+  if (!azureResponse.NBest || !azureResponse.NBest[0] || !azureResponse.NBest[0].Words) {
+    return problematic;
+  }
+  
+  azureResponse.NBest[0].Words.forEach((word: any) => {
+    if (word.Phonemes) {
+      word.Phonemes.forEach((phoneme: any, index: number) => {
+        if (phoneme.AccuracyScore < 80) { // Threshold for "needs improvement"
+          let position = 'middle';
+          if (index === 0) position = 'beginning';
+          if (index === word.Phonemes.length - 1) position = 'end';
+          
+          problematic.push({
+            phoneme: phoneme.Phoneme,
+            word: word.Word,
+            accuracy: phoneme.AccuracyScore,
+            position
+          });
+        }
+      });
+    }
+  });
+  
+  return problematic;
+}
+
+async function generateDrillSuggestions(problematicSounds: PhonemeAnalysis[], azureResponse: any): Promise<DrillSuggestion> {
+  const originalText = azureResponse.DisplayText || '';
+  const language = extractLanguageFromResponse(azureResponse);
+  
+  // Prepare prompt for GPT-4o
+  const prompt = `As a pronunciation coach, analyze these problematic sounds and create a targeted follow-up drill:
+
+**Original phrase**: "${originalText}"
+**Language**: ${language}
+
+**Problematic sounds**:
+${problematicSounds.map(p => `- /${p.phoneme}/ in "${p.word}" (${p.accuracy}% accuracy, ${p.position} of word)`).join('\n')}
+
+Please provide:
+1. **Focus**: What specific sound(s) to work on
+2. **Explanation**: Why this sound is challenging and what's likely going wrong
+3. **Exercises**: 4-5 specific practice phrases focusing on these problem sounds
+4. **Tips**: 2-3 concrete pronunciation tips (tongue/lip position, breath control, etc.)
+
+Keep exercises at similar difficulty level to the original phrase. Make them practical and engaging.
+
+Response format (JSON):
+{
+  "focus": "brief description",
+  "explanation": "why this is challenging",
+  "exercises": ["phrase 1", "phrase 2", "phrase 3", "phrase 4"],
+  "tips": ["tip 1", "tip 2", "tip 3"]
+}`;
+
+  try {
+    const response = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${import.meta.env.VITE_OPENAI_API_KEY}`,
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        model: 'gpt-4o',
+        messages: [
+          {
+            role: 'system',
+            content: 'You are an expert pronunciation coach who creates targeted drills based on speech analysis data. Always respond with valid JSON.'
+          },
+          {
+            role: 'user',
+            content: prompt
+          }
+        ],
+        temperature: 0.7,
+        max_tokens: 800
+      })
+    });
+
+    if (!response.ok) {
+      throw new Error(`OpenAI API error: ${response.status}`);
+    }
+
+    const data = await response.json();
+    const content = data.choices[0].message.content;
+    
+    // Parse JSON response
+    const suggestion = JSON.parse(content);
+    
+    return {
+      focus: suggestion.focus || 'Sound practice',
+      explanation: suggestion.explanation || 'Focus on problematic sounds',
+      exercises: suggestion.exercises || [],
+      tips: suggestion.tips || []
+    };
+    
+  } catch (error) {
+    console.error('Failed to generate AI drill suggestions:', error);
+    
+    // Fallback to rule-based suggestions
+    return generateFallbackSuggestions(problematicSounds);
+  }
+}
+
+function extractLanguageFromResponse(azureResponse: any): string {
+  // Extract language from response or default to English
+  return 'English (US)'; // Could be enhanced to detect from Azure response
+}
+
+function generateFallbackSuggestions(problematicSounds: PhonemeAnalysis[]): DrillSuggestion {
+  const uniquePhonemes = [...new Set(problematicSounds.map(p => p.phoneme))];
+  
+  return {
+    focus: `Practice ${uniquePhonemes.map(p => `/${p}/`).join(', ')} sounds`,
+    explanation: `These sounds scored below 80% accuracy and need focused practice.`,
+    exercises: [
+      'Try repeating the original phrase slowly',
+      'Practice each word individually', 
+      'Focus on mouth position for problem sounds',
+      'Record and compare with native speaker'
+    ],
+    tips: [
+      'Slow down and emphasize problem sounds',
+      'Use a mirror to check mouth position',
+      'Practice with exaggerated movements first'
+    ]
+  };
+}
+
+/**
+ * Check if we should offer drill suggestions based on the results
+ */
+export function shouldOfferDrillSuggestions(azureScore: any): boolean {
+  if (!azureScore || !azureScore.json) return false;
+  
+  // Offer drills if overall pronunciation is below 85% or if we have problematic phonemes
+  if (azureScore.pronunciation < 85) return true;
+  
+  const problematic = extractProblematicPhonemes(azureScore.json);
+  return problematic.length > 0;
+}

--- a/packages/azure-speech/src/useAzurePronunciation.ts
+++ b/packages/azure-speech/src/useAzurePronunciation.ts
@@ -37,65 +37,132 @@ interface AzureResponse {
   }>;
 }
 
+import { convertToWav, needsConversion, getAudioInfo } from './audioConverter';
+
 export async function useAzurePronunciation(
-  blob: Blob,      // WAV/PCM recording
+  blob: Blob,      // Audio recording (any format)
   refText: string,
   locale = 'en-US'
 ): Promise<AzureScore> {
   const startTime = performance.now();
   
+  console.log('Original audio info:', getAudioInfo(blob));
+  
+  // Convert to WAV if needed
+  let processedBlob = blob;
+  if (needsConversion(blob)) {
+    console.log('Converting audio to WAV format for Azure compatibility...');
+    try {
+      processedBlob = await convertToWav(blob);
+      console.log('Converted audio info:', getAudioInfo(processedBlob));
+    } catch (error) {
+      console.warn('Audio conversion failed, using original format:', error);
+    }
+  }
+  
   // Calculate cost: $1 per audio hour
-  // Assume 32000 bytes per second for WAV/PCM
-  const durationSeconds = blob.size / 32000;
+  // For WAV/PCM: 16kHz * 2 bytes = 32000 bytes per second
+  const durationSeconds = processedBlob.size / 32000;
   const costUSD = Math.round((durationSeconds / 3600) * 1 * 100) / 100; // Round to 2 decimals
   
   // Prepare pronunciation assessment parameters
   const pronunciationAssessment = {
     ReferenceText: refText,
-    GradingSystem: "HundredMark"
+    GradingSystem: "HundredMark",
+    Granularity: "Phoneme",
+    Dimension: "Comprehensive"
   };
   
-  const pronunciationParam = btoa(JSON.stringify(pronunciationAssessment));
+  // Use base64 encoding that handles Unicode characters
+  const pronunciationParam = btoa(unescape(encodeURIComponent(JSON.stringify(pronunciationAssessment))));
   
-  // Azure region and endpoint
+  // Azure region and endpoint for pronunciation assessment
   const region = import.meta.env.VITE_AZURE_SPEECH_REGION || 'westus2';
   const endpoint = `https://${region}.stt.speech.microsoft.com/speech/recognition/conversation/cognitiveservices/v1`;
   
   const url = new URL(endpoint);
   url.searchParams.set('language', locale);
-  url.searchParams.set('pronunciationAssessment', pronunciationParam);
+  url.searchParams.set('format', 'detailed');
+  url.searchParams.set('profanity', 'raw');
+  
+  console.log('Pronunciation assessment config:', pronunciationAssessment);
+  console.log('Base64 encoded config:', pronunciationParam);
   
   try {
     // Convert blob to ArrayBuffer for the request
-    const audioData = await blob.arrayBuffer();
+    const audioData = await processedBlob.arrayBuffer();
+    
+    // Determine content type based on processed blob type
+    let contentType = 'audio/wav; codecs=audio/pcm; samplerate=16000';
+    if (processedBlob.type.includes('webm')) {
+      contentType = 'audio/webm; codecs=opus';
+    } else if (processedBlob.type.includes('ogg')) {
+      contentType = 'audio/ogg; codecs=opus';
+    }
+    
+    console.log('Sending audio to Azure:', { 
+      originalType: blob.type,
+      processedType: processedBlob.type,
+      contentType, 
+      originalSize: blob.size,
+      processedSize: processedBlob.size,
+      refText: refText 
+    });
     
     const response = await fetch(url.toString(), {
       method: 'POST',
       headers: {
         'Ocp-Apim-Subscription-Key': import.meta.env.VITE_AZURE_SPEECH_KEY || 'your-azure-key',
-        'Content-Type': 'audio/wav; codecs=audio/pcm; samplerate=16000',
-        'Accept': 'application/json'
+        'Content-Type': contentType,
+        'Accept': 'application/json',
+        'Pronunciation-Assessment': pronunciationParam
       },
       body: audioData
     });
     
+    console.log('Azure API response status:', response.status, response.statusText);
+    console.log('Azure API response headers:', Object.fromEntries(response.headers.entries()));
+    
     if (!response.ok) {
-      throw new Error(`Azure API error: ${response.status} ${response.statusText}`);
+      const errorText = await response.text();
+      console.log('Azure API error response:', errorText);
+      throw new Error(`Azure API error: ${response.status} ${response.statusText} - ${errorText}`);
     }
     
     const result: AzureResponse = await response.json();
     const latencyMs = Math.round(performance.now() - startTime);
     
+    // Log the full response for debugging
+    console.log('Azure Speech API response:', result);
+    console.log('Response keys:', Object.keys(result));
+    console.log('Response JSON:', JSON.stringify(result, null, 2));
+    
     // Extract scores from the response
     if (result.NBest && result.NBest.length > 0) {
-      const assessment = result.NBest[0].PronunciationAssessment;
+      const bestResult = result.NBest[0];
       
+      console.log('Best result object:', bestResult);
+      console.log('Available keys in bestResult:', Object.keys(bestResult));
+      
+      // Azure returns scores directly in NBest[0] for pronunciation assessment
       return {
-        pronunciation: Math.round(assessment.PronScore),
-        accuracy: Math.round(assessment.AccuracyScore),
-        fluency: Math.round(assessment.FluencyScore),
-        completeness: Math.round(assessment.CompletenessScore),
+        pronunciation: Math.round(bestResult.PronScore || 0),
+        accuracy: Math.round(bestResult.AccuracyScore || 0),
+        fluency: Math.round(bestResult.FluencyScore || 0),
+        completeness: Math.round(bestResult.CompletenessScore || 0),
         json: result,
+        latencyMs,
+        costUSD
+      };
+    } else if (result.RecognitionStatus === 'Success' && result.DisplayText === '') {
+      // Azure processed audio but couldn't extract speech (likely format issue)
+      console.warn('Azure recognized audio but extracted no text - possibly unsupported audio format');
+      return {
+        pronunciation: 0,
+        accuracy: 0,
+        fluency: 0,
+        completeness: 0,
+        json: { ...result, warning: 'Audio format may not be supported for pronunciation assessment' },
         latencyMs,
         costUSD
       };


### PR DESCRIPTION
…d drills

Major pronunciation coaching breakthrough with Azure Speech Services integration:

Azure Speech Assessment:
- WebM → WAV audio conversion using Web Audio API
- Real-time pronunciation scoring (accuracy, fluency, completeness)
- Phoneme-level analysis with detailed breakdowns
- Cost tracking with $3 daily budget system
- Environment variables: VITE_AZURE_SPEECH_KEY, VITE_AZURE_SPEECH_REGION

AI-Powered Drill Generation:
- GPT-4o analyzes problematic sounds from Azure data
- Generates targeted practice exercises for specific phonemes
- Provides pronunciation tips and explanations
- Triggers automatically when scores < 85%

Technical Implementation:
- Enhanced MediaRecorder with format detection and fallbacks
- Proper Azure API headers and pronunciation assessment config
- Comprehensive error handling and fallback mechanisms
- Detailed UI with color-coded phoneme analysis
- Test compatibility with mock environments

Files:
- audioConverter.ts: WebM→WAV conversion using Web Audio API
- pronunciationAnalyzer.ts: AI drill generation with GPT-4o
- PronunciationCoach.tsx: Enhanced recording with audio capture
- useAzurePronunciation.ts: Azure Speech Services integration
- PronunciationCoachUI.tsx: Rich pronunciation analysis UI

🤖 Generated with [Claude Code](https://claude.ai/code)

### Context
Re-enabled all PronunCo tests; now 5 files are failing (no hangs).

### Failing suites
- clear-decks.test.tsx – “Groceries” not found
- coach-page.test.tsx – prompt “hello” not rendered
- deck-manager.navigate.test.tsx – label “Select A” not found
- drill-link.test.tsx – deck prop undefined
- storage-hooks.test.tsx – Dexie snapshot empty

### Task list
- [ ] Update seed/mocks so expected elements render.
- [ ] Pass required props (`deck`) in DrillLink test or loosen assertion.
- [ ] Ensure Dexie writes finish before hook assertion (use `await` or `waitFor`).
- [ ] Keep `beforeEach` fake-timer cleanup pattern if timers used.
- [ ] Run `pnpm --filter ./apps/pronunco vitest run` until 0 failures.
CI will fail on the PR (expected); Codex fixes each test and pushes until it’s green.
