### PR TITLE
Claude/docs archive reorg

### DIFF
--- a/docs/10_pronunco/features/003-sound-muscle-memory-system.md
+++ b/docs/10_pronunco/features/003-sound-muscle-memory-system.md
@@ -1,0 +1,209 @@
+# Sound Muscle Memory System
+
+## 🎯 **Core Concept**
+
+Build speech muscle memory through targeted phoneme drilling - like practicing tennis forehand against a wall. Focus on **repetitive practice of problematic sounds** to develop automatic, accurate pronunciation.
+
+## 🧠 **The Vision: Multi-Layered Drill Architecture**
+
+### **Current State**
+- ✅ Topic-based pronunciation drills (hotel, restaurant, etc.)
+- ✅ Azure Speech Assessment with phoneme-level analysis
+- ✅ AI-generated targeted practice suggestions
+- ✅ Real-time pronunciation scoring
+
+### **Next Evolution: Sound-Focused Training**
+
+## 🔧 **Technical Architecture Requirements**
+
+### **1. Drill Deck Hierarchy**
+```
+📁 Topic Decks (existing)
+├── 🏨 Hotel Reception
+├── 🍽️ Restaurant
+└── 🛒 Grocery Shopping
+
+📁 Sound Decks (new)
+├── 🔤 /th/ Sound Mastery
+├── 🔤 /r/ vs /l/ Distinction  
+├── 🔤 Vowel Precision (/æ/, /ɛ/, /ɪ/)
+└── 🔤 Consonant Clusters (/br/, /pr/, /tr/)
+
+📁 Grammar Decks (future)
+├── 📝 Past Tense Pronunciation
+├── 📝 Question Intonation
+└── 📝 Stress Patterns
+```
+
+### **2. Cross-Deck Linking System**
+- **Topic → Sound Mapping**: Hotel deck identifies user struggles with /th/ → links to /th/ Sound Deck
+- **Sound → Topic Application**: After /th/ mastery → return to hotel phrases with improved confidence
+- **Progress Synchronization**: Success in sound drills updates topic deck assessments
+
+### **3. Assessment Data Aggregation**
+
+#### **User-Level Analytics**
+```typescript
+interface UserSoundProfile {
+  userId: string;
+  soundAccuracy: {
+    [phoneme: string]: {
+      averageScore: number;
+      improvementRate: number;
+      practiceCount: number;
+      lastPracticed: Date;
+      problematicContexts: string[]; // "word-initial", "consonant-cluster", etc.
+    }
+  };
+  topicDeckPerformance: {
+    [deckId: string]: {
+      overallScore: number;
+      problematicSounds: string[];
+      masteredSounds: string[];
+    }
+  };
+}
+```
+
+#### **Topic Deck Sound Profiling**
+```typescript
+interface TopicDeckSoundProfile {
+  deckId: string;
+  primarySounds: string[]; // Most frequent phonemes in this deck
+  challengingSounds: string[]; // Sounds that typically cause difficulty
+  soundFrequency: {
+    [phoneme: string]: number; // How often this sound appears
+  };
+  recommendedSoundDecks: string[]; // Suggested sound drills for this topic
+}
+```
+
+## 🎯 **Feature Specifications**
+
+### **Phase 1: Sound Deck Foundation**
+1. **Sound Deck Creation Interface**
+   - Create drills focused on specific phonemes
+   - Import phrases that heavily feature target sounds
+   - Difficulty progression (isolated sound → words → phrases → sentences)
+
+2. **Cross-Deck Navigation**
+   - "Improve /th/ sounds" button in topic deck results
+   - "Apply to hotel phrases" button in sound deck
+   - Breadcrumb navigation between related decks
+
+3. **Enhanced Assessment Data**
+   - Track phoneme accuracy across all decks
+   - Identify consistent problem sounds
+   - Monitor improvement over time
+
+### **Phase 2: Intelligent Sound Recommendations**
+4. **Automatic Sound Deck Suggestions**
+   - Analyze topic deck performance → recommend specific sound drills
+   - "You struggled with /r/ sounds. Practice with 'R-Sound Mastery' deck?"
+   - Progressive difficulty based on current skill level
+
+5. **Sound Profiling Engine**
+   - Pre-analyze topic decks for sound complexity
+   - Tag phrases by primary phonemes
+   - Create reusable sound difficulty ratings
+
+6. **Adaptive Practice Scheduling**
+   - Spaced repetition for problematic sounds
+   - "You haven't practiced /th/ sounds in 3 days - quick drill?"
+   - Intensity adjustment based on improvement rate
+
+### **Phase 3: Professional Training Interface**
+7. **Pro-Level Management Dashboard**
+   - Large-surface interface for comprehensive deck management
+   - Visual phoneme progress charts
+   - Bulk deck operations and linking
+
+8. **Advanced Analytics Panel**
+   - Heatmap of pronunciation accuracy by phoneme
+   - Progress trends over time
+   - Comparative analysis across topic areas
+
+9. **Sound Deck Reusability System**
+   - One /th/ deck → links to multiple topic decks (hotel, restaurant, grocery)
+   - Shared sound deck library
+   - Community-created sound drilling exercises
+
+## 🏗️ **Implementation Strategy**
+
+### **Database Schema Additions**
+```sql
+-- Sound Decks table
+CREATE TABLE sound_decks (
+  id TEXT PRIMARY KEY,
+  phoneme_focus TEXT NOT NULL,
+  difficulty_level INTEGER,
+  created_at TIMESTAMP,
+  phrases TEXT[], -- JSON array of practice phrases
+  metadata JSONB -- progression rules, tips, etc.
+);
+
+-- Deck relationships
+CREATE TABLE deck_relationships (
+  parent_deck_id TEXT,
+  child_deck_id TEXT,
+  relationship_type TEXT, -- 'sound_drill', 'grammar_drill', 'prerequisite'
+  strength FLOAT -- how closely related (0-1)
+);
+
+-- User sound assessments
+CREATE TABLE user_sound_assessments (
+  user_id TEXT,
+  phoneme TEXT,
+  deck_id TEXT,
+  accuracy_score FLOAT,
+  timestamp TIMESTAMP,
+  context_data JSONB -- word position, surrounding sounds, etc.
+);
+```
+
+### **UI Components Needed**
+- **Sound Deck Creator**: Interface for building phoneme-focused drills
+- **Cross-Deck Navigator**: Seamless movement between topic/sound/grammar decks  
+- **Progress Dashboard**: Comprehensive view of phoneme mastery
+- **Smart Recommendations**: AI-driven suggestions for next practice steps
+
+## 🎨 **User Experience Flow**
+
+### **Muscle Memory Training Loop**
+1. **Practice topic deck** (hotel phrases) → identify /th/ weakness
+2. **Drill /th/ sounds** → intensive muscle memory training
+3. **Return to hotel deck** → apply improved /th/ pronunciation
+4. **Monitor progress** → track /th/ improvement across all contexts
+5. **Expand to new topics** → apply /th/ mastery to restaurant, grocery, etc.
+
+### **Professional Coach Interface**
+- **Deck Management Canvas**: Visual interface for linking topic/sound/grammar decks
+- **Student Progress Overview**: Class-wide phoneme mastery tracking
+- **Curriculum Planning**: Sequence recommendations based on sound complexity
+- **Assessment Analytics**: Detailed reporting on pronunciation development
+
+## 🚀 **Future Extensions**
+
+### **Advanced Muscle Memory Features**
+- **Articulatory Feedback**: Visual tongue/lip position guides
+- **Rhythm Training**: Metronome-based pronunciation drilling
+- **Breath Control**: Integration with speech breathing techniques
+- **Accent Reduction**: Systematic native-language interference analysis
+
+### **AI-Powered Enhancements**
+- **Personalized Sound Sequences**: AI determines optimal drilling order
+- **Contextual Difficulty**: Adjust based on surrounding phonemes
+- **Progress Prediction**: Estimate time to phoneme mastery
+- **Intelligent Spaced Repetition**: Optimize review timing per sound
+
+## 📝 **Next Steps for Discussion with GPT-4o**
+
+1. **Sound Deck Content Strategy**: How to create effective muscle memory drills?
+2. **Difficulty Progression**: What's the optimal sequence for phoneme training?
+3. **Cross-Deck Integration**: Best UX for seamless topic/sound navigation?
+4. **Assessment Granularity**: How detailed should phoneme tracking be?
+5. **Professional Interface Design**: What tools do pronunciation coaches need?
+
+---
+
+*This document captures the vision for transforming pronunciation practice from topic-based learning to systematic muscle memory development through targeted sound drilling.*

--- a/docs/development/current-priorities.md
+++ b/docs/development/current-priorities.md
@@ -1,109 +1,166 @@
 # Current Development Priorities
 
-## Active Work Stream
-**Status**: ✅ COMPLETED - GitHub Deployment Pipeline Fixed
-**Started**: 2025-07-17
-**Completed**: 2025-07-17
+*Last updated: 2025-07-17*
 
-## Shelved/Interrupted Work
-- **Coach Desktop UI Enhancements**: 3-tabbed right panel completed, ready for next PR
-- **Mobile UI refinements**: Two-column coach layout issues documented in PR
-- **Device testing**: Mobile layouts on actual devices (low priority)
+## 🎯 **Active Focus: Sound Muscle Memory System**
 
-## Follow-up Ideas (Future Enhancements)
+### **Current Achievement**
+✅ **Azure Speech Assessment Integration Complete**
+- WebM→WAV audio conversion with Web Audio API
+- Real-time phoneme-level pronunciation analysis  
+- AI-powered drill generation using GPT-4o
+- Budget management and cost tracking
+- Rich visual feedback with color-coded phonemes
 
-### **Deck Enhancement Wizard Polish** 🔧
-1. **Add "New Folder" to folder selection**: Avoid multi-step route for new folder creation
-2. ✅ **Sweet G-V indicators in Deck Manager**: Bring 📖V 📝G 💡B/I/A indicators to main deck list
-3. **Tabbed layout for long drills**: Prevent tall forms with tabs (Content | Enhancement Options | Folder Selection)
-4. ✅ **Group deck selection by folder**: Organize long dropdown lists by folders
-5. ✅ **Add legend/hover info**: Explain what V/G/I indicators mean
+### **Next Major Initiative: Muscle Memory Training Architecture**
 
-*Captured: 2025-07-16 - User feedback after successful implementation*
+#### **Core Concept**
+Transform from topic-based drilling to **systematic sound muscle memory development** - like practicing tennis forehand against a wall, but for speech articulation.
 
-### **Coach UI Follow-up Items** 🎤
-1. **Tab width optimization**: How to fit more tabs on students' pane? 
-   - Shortened tab text + hover feedback expansion?
-   - Make pane wider?
-   - Introduce "active pane" concept (wide active, narrow inactive)?
-2. **Grammar translation language mixing**: German phrases read with heavy English accent or vice versa
-   - Need 4o to change pattern for grammar to fit our concept
-   - Currently using language detection heuristics as temporary fix
-3. **Vocabulary translation/read-out language confusion**: Same mixing issue as grammar
-   - Vocabulary words vs definitions using different languages
-   - Need better AI prompt engineering for language-specific content
+#### **Priority Implementation Phases**
 
-*Captured: 2025-07-16 - User feedback after coach UI improvements*
+**Phase 1: Foundation (Next Sprint)**
+- [ ] Sound Deck creation interface
+- [ ] Cross-deck linking system (Topic ↔ Sound)
+- [ ] Enhanced assessment data aggregation
+- [ ] User sound profiling analytics
 
-### **Technical Debt** 🔧
-1. **Fix TypeScript build errors**: Currently skipping TS checks for deployment
-   - Source code has type errors (missing properties, module imports)
-   - Need to fix type definitions and imports
-   - ~25 TypeScript errors to resolve
-2. **Clean up test files**: Some test files have outdated imports/types
-   - Already excluded from build, but should be fixed for development
+**Phase 2: Intelligence (Following Sprint)**  
+- [ ] Automatic sound deck recommendations
+- [ ] Topic deck sound profiling engine
+- [ ] Adaptive practice scheduling with spaced repetition
+- [ ] Smart difficulty progression
 
-*Captured: 2025-07-16 - Build deployment preparation*
+**Phase 3: Professional Interface (Future)**
+- [ ] Large-surface management dashboard
+- [ ] Advanced analytics and progress visualization
+- [ ] Sound deck reusability across topics
+- [ ] Community sound deck sharing
 
-### **GitHub Deployment Pipeline Issues** 🚀 - RESOLVED
-1. ✅ **Claude CLI VS Code extension**: Fixed corrupted VSIX file issue
-2. ✅ **GitHub CLI authentication**: Fixed with `export GIT_CONFIG_NOSYSTEM=1` workaround
-3. ✅ **Netlify plugin removal**: Removed blocking GitHub plugin integration
-4. ✅ **Manual deployment setup**: Added `netlify.toml` for manual deployment
-5. ✅ **Clean CI workflow**: Removed failing deployment workflow, kept working CI
+### **Technical Architecture Needs**
 
-**Resolution**: Deployment pipeline now works smoothly with manual Netlify deployment option
+#### **Database Extensions**
+- Sound decks table with phoneme focus
+- Deck relationship mapping (topic→sound→grammar)
+- Granular user sound assessment tracking
+- Cross-deck progress synchronization
 
-*Captured: 2025-07-17 - Deployment pipeline investigation*  
-*Resolved: 2025-07-17 - All deployment issues fixed*
+#### **UI Components**
+- Sound Deck Creator interface
+- Cross-Deck Navigator for seamless transitions
+- Progress Dashboard with phoneme mastery tracking
+- Smart Recommendation engine integration
+
+### **Strategic Goals**
+1. **Muscle Memory Development**: Repetitive phoneme drilling for automatic pronunciation
+2. **Systematic Progress**: Track improvement across all contexts (hotel, restaurant, etc.)
+3. **Professional Tools**: Large-surface interface for coaches and advanced users
+4. **Reusable Content**: One /th/ deck serves multiple topic areas
+
+### **Key Questions for GPT-4o Discussion**
+- Sound deck content strategy and progression difficulty
+- Optimal muscle memory training sequences
+- Cross-deck UX design patterns
+- Professional coach interface requirements
+
+---
+
+## 📋 **Backlog Items**
+
+### **Immediate (This Week)**
+- [ ] Test Azure Speech Assessment in production
+- [ ] Document environment variable setup process
+- [ ] Create sound deck wireframes and user flow
+
+### **Short-term (Next 2 Weeks)**
+- [ ] Design sound deck database schema
+- [ ] Implement basic sound deck creation UI
+- [ ] Build cross-deck navigation prototype
+
+### **Medium-term (Next Month)**
+- [ ] Complete Phase 1 sound muscle memory system
+- [ ] Advanced analytics for phoneme tracking
+- [ ] Professional dashboard mockups
+
+### **Long-term (Next Quarter)**
+- [ ] Full muscle memory training system
+- [ ] Community sound deck sharing
+- [ ] Mobile PWA optimizations
+- [ ] Multi-language expansion
+
+---
+
+## 🔄 **Context Persistence Notes**
+
+**What we just completed:**
+- Full Azure Speech Assessment integration with real-time phoneme analysis
+- AI-powered drill generation using GPT-4o for targeted practice
+- Professional-grade audio processing pipeline
+- Comprehensive cost tracking and budget management
+
+**Where we're heading:**
+- Systematic muscle memory training architecture
+- Multi-layered drill deck system (topic/sound/grammar)
+- Professional coaching tools with advanced analytics
+- Reusable sound content across multiple contexts
+
+**Technical foundation:**
+- Solid Azure Speech Services integration
+- GPT-4o AI analysis capabilities  
+- Cross-browser audio processing
+- Robust error handling and fallback systems
+
+---
+
+## 📚 **Previously Completed Work**
+
+### **Azure Speech Assessment Implementation** ✅
+**Status**: COMPLETED - 2025-07-17
+- WebM to WAV audio conversion using Web Audio API
+- Real-time pronunciation scoring with Azure Speech Services
+- Phoneme-level analysis with color-coded visual feedback
+- AI-powered drill generation using GPT-4o for problematic sounds
+- Budget management with $3 daily limit and cost tracking
+- Cross-browser compatibility with MediaRecorder fallbacks
+
+### **GitHub Deployment Pipeline** ✅ 
+**Status**: COMPLETED - 2025-07-17
+- Claude CLI VS Code extension corruption fixed
+- GitHub CLI authentication resolved
+- Netlify plugin removal for manual deployment
+- Clean CI workflow with working tests
+
+### **Coach Desktop UI Enhancements** ✅
+**Status**: COMPLETED - 2025-07-16
+- 3-tabbed right panel (Drill | Vocabulary | Grammar)
+- Unified Play/Record/Translate controls
+- G-V indicators in deck manager (📖V 📝G 💡B/I/A)
+- Enhanced deck enhancement wizard
+
+### **Deck Enhancement Wizard** ✅
+**Status**: COMPLETED - 2025-07-16  
+- "Enhance Existing Deck" mode added
+- Smart deck dropdown with metadata indicators
+- AI-powered vocabulary and grammar generation
+- Granular enhancement options
+
+---
+
+## 📖 **Legacy Backlog Items**
 
 ### **Coach UI Polish** 🎤
-1. ✅ **Remove redundant top tab bar**: Student pane tabs duplicate top navigation
-2. ✅ **Drill-pattern vocabulary**: Show selected word above controls like drill items
-3. ✅ **Record/score vocabulary**: Apply same pronunciation scoring to vocab words
-4. ✅ **Unified interaction pattern**: Consistent UX across drill items and vocabulary
-5. ✅ **Add G-V indicators to deck manager**: Display 📖V 📝G 💡B/I/A indicators in main deck list
-6. ✅ **Add legend/hover info**: Tooltips explain what indicators mean
+1. **Tab width optimization**: Fit more tabs on students' pane
+2. **Grammar translation language mixing**: German phrases with English accent
+3. **Vocabulary translation language confusion**: Mixed language definitions
 
-*Captured: 2025-07-16 - User feedback after tabbed interface implementation*
+### **Technical Debt** 🔧
+1. **TypeScript build errors**: ~25 errors to resolve
+2. **Test file cleanup**: Outdated imports and types
 
-## Next Business PR - Desktop Improvements
-**Context**: We were about to start working on desktop business functionality before VSCode crash and mobile UI diversion.
-
-### Planned Desktop Improvements:
-
-#### 1. **Deck Enhancement Wizard** 🔧
-Add third mode to wizard: "Enhance Existing Deck"
-- **Problem**: Early decks lack vocab and grammar sections
-- **Solution**: AI-powered deck enrichment
-- **Features**:
-  - Load existing deck → Generate missing vocab/grammar
-  - Create difficulty progression (Basic → Intermediate → Advanced)
-  - Link related difficulty levels for easy navigation
-  - Preserve original deck, create enhanced versions
-
-#### 2. **Coach Desktop UI Enhancements** 🎤
-**Problem**: Students must navigate to top tabs to access vocab/grammar - unclear and disruptive to flow
-**Solution**: Right-panel tabbed content with unified controls
-- **3-Tabbed Right Panel**: Drill Items | Vocabulary | Grammar
-- **Unified Controls**: Play/Record/Translate apply to active tab content
-- **Better UX Flow**: Access vocabulary/grammar without leaving practice area
-- **Clear Tab Purpose**: Obvious what each tab contains and does
-
-#### 3. **Difficulty Progression System** 📈
-- **Deck Families**: Group related decks by difficulty
-- **Smart Navigation**: "Too hard? Try Basic" / "Too easy? Try Advanced"
-- **Reference System**: Link between difficulty variants
-- **UI Indicators**: Show progression path in deck manager
-
-### ✅ Implementation Completed:
-- ✅ Added third wizard mode: "🔧 Enhance Existing Deck"
-- ✅ Smart deck dropdown with metadata indicators (📖V 📝G 💡B/I/A)
-- ✅ Two-step enhancement flow: Deck preview → Enhancement selection
-- ✅ Granular options: Vocabulary only, Grammar only, or both
-- ✅ AI prompts for targeted content generation
-- ✅ Preview screen shows current deck content and metadata
-- ✅ Context-aware enhancement decisions
+### **Deck Enhancement Wizard Polish** 🔧
+1. **Add "New Folder" to folder selection**
+2. **Tabbed layout for long drills** 
+3. **Enhanced folder organization**
 
 ---
 
@@ -113,4 +170,4 @@ Add third mode to wizard: "Enhance Existing Deck"
 - Reference this file to resume interrupted work
 - Keep "shelved" items for future pickup
 
-*Last updated: 2025-07-16*
+*Continue with sound muscle memory system development as next major milestone.*

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,26 @@
+server {
+    listen 80;
+    server_name localhost;
+    root /usr/share/nginx/html;
+    index index.html;
+    
+    # Enable gzip
+    gzip on;
+    gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript;
+    
+    # Handle SPA routing
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+    
+    # API proxy if needed (future)
+    # location /api/ {
+    #     proxy_pass http://host.docker.internal:3001;
+    # }
+    
+    # Cache static assets
+    location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2)$ {
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+    }
+}


### PR DESCRIPTION
### Context
Re-enabled all PronunCo tests; now 5 files are failing (no hangs).

### Failing suites
- clear-decks.test.tsx – “Groceries” not found
- coach-page.test.tsx – prompt “hello” not rendered
- deck-manager.navigate.test.tsx – label “Select A” not found
- drill-link.test.tsx – deck prop undefined
- storage-hooks.test.tsx – Dexie snapshot empty

### Task list
- [ ] Update seed/mocks so expected elements render.
- [ ] Pass required props (`deck`) in DrillLink test or loosen assertion.
- [ ] Ensure Dexie writes finish before hook assertion (use `await` or `waitFor`).
- [ ] Keep `beforeEach` fake-timer cleanup pattern if timers used.
- [ ] Run `pnpm --filter ./apps/pronunco vitest run` until 0 failures.
CI will fail on the PR (expected); Codex fixes each test and pushes until it’s green.
